### PR TITLE
fix(farm): SideJump bidirectional topology and rest seek failover

### DIFF
--- a/Application/MapEditor/MapEditorValidationService.cs
+++ b/Application/MapEditor/MapEditorValidationService.cs
@@ -366,7 +366,7 @@ namespace ArtaleAI.Application.MapEditor
             foreach (var anchor in mapData.ManualEdgeAnchors)
             {
                 if (anchor.ActionType is NavigationActionType.Walk or NavigationActionType.ClimbUp
-                    or NavigationActionType.ClimbDown)
+                    or NavigationActionType.ClimbDown or NavigationActionType.SideJump)
                     continue;
 
                 if (!TryResolveNodeId(nodeById, anchor.FromPlatformId, anchor.FromX, anchor.FromY, out string fromId))

--- a/Application/Pipeline/GamePipeline.cs
+++ b/Application/Pipeline/GamePipeline.cs
@@ -75,9 +75,20 @@ namespace ArtaleAI.Application.Pipeline
 
         /// <summary>選點或強制目標規劃失敗時的重試節流，避免每幀重跑 A*。</summary>
         private const int RestSeekRetrySeconds = 3;
+
+        /// <summary>
+        /// 單一休息點的尋路預算：超過即判定不可達並故障轉移到下一個候選點。
+        /// 沒有這道停損，選點誤判（起點跨平台誤對齊、拓撲斷邊）會讓 Seeking
+        /// 無限重試，而 Seeking 期間攻擊全面關閉＝自動打怪永久停擺。
+        /// </summary>
+        private const int RestSeekTimeoutSeconds = 45;
+
         private DateTime _restEndsAtUtc = DateTime.MinValue;
         private DateTime _nextRestDueUtc = DateTime.MinValue;
         private DateTime _nextRestSeekRetryUtc = DateTime.MinValue;
+        private DateTime _restSeekStartedUtc = DateTime.MinValue;
+        private string? _restSeekGoalNodeId;
+        private readonly HashSet<string> _restSeekFailedNodeIds = new(StringComparer.Ordinal);
         private int _attackInputLease;
         private int _monsterDetectionInFlight;
         private int _monsterJobReplacementCount;
@@ -578,6 +589,8 @@ namespace ArtaleAI.Application.Pipeline
         {
             if (_restPhase == RestPhaseNone) return;
             _restPhase = RestPhaseNone;
+            _restSeekGoalNodeId = null;
+            _restSeekFailedNodeIds.Clear();
             RestNavigationTracker?.ClearForcedGoal();
         }
 
@@ -621,6 +634,8 @@ namespace ArtaleAI.Application.Pipeline
                 return;
             }
 
+            _restSeekFailedNodeIds.Clear();
+
             var selection = RestSpotSelector.Select(graph, playerPos.Value);
             switch (selection.Outcome)
             {
@@ -634,13 +649,29 @@ namespace ArtaleAI.Application.Pipeline
                     return;
             }
 
-            tracker.SetForcedGoal(selection.Node!.Id);
-            _restPhase = RestPhaseSeeking;
-            string spotKind = selection.Node.Type == NavigationNodeType.Rope ? "繩索" : "安全區";
-            OnStatusMessage?.Invoke($"休息時間到，前往{spotKind}休息點…");
+            BeginSeekingToward(tracker, selection.Node!, now, "休息時間到");
         }
 
-        /// <summary>SeekingRest：等待強制目標到達；規劃停擺時節流重試，直到到達才開始倒數。</summary>
+        /// <summary>注入強制目標並重置本次尋路的逾時基準點。</summary>
+        private void BeginSeekingToward(
+            PathPlanningTracker tracker,
+            NavigationNode spot,
+            DateTime now,
+            string prefix)
+        {
+            tracker.SetForcedGoal(spot.Id);
+            _restSeekGoalNodeId = spot.Id;
+            _restSeekStartedUtc = now;
+            _restPhase = RestPhaseSeeking;
+            string spotKind = spot.Type == NavigationNodeType.Rope ? "繩索" : "安全區";
+            OnStatusMessage?.Invoke($"{prefix}，前往{spotKind}休息點…");
+        }
+
+        /// <summary>
+        /// SeekingRest：等待強制目標到達；規劃停擺時節流重試。
+        /// 超過尋路預算即視為不可達，故障轉移到下一個候選休息點；
+        /// 候選耗盡才降級原地小休。保證 Seeking 有界，不會凍結自動打怪。
+        /// </summary>
         private void ProcessRestSeeking(AppConfig config, DateTime now)
         {
             var tracker = RestNavigationTracker;
@@ -657,11 +688,47 @@ namespace ArtaleAI.Application.Pipeline
                 return;
             }
 
+            if ((now - _restSeekStartedUtc).TotalSeconds > RestSeekTimeoutSeconds)
+            {
+                FailOverToNextRestSpot(tracker, config, now);
+                return;
+            }
+
             if (tracker.IsForcedGoalPlanningParked && now >= _nextRestSeekRetryUtc)
             {
                 _nextRestSeekRetryUtc = now.AddSeconds(RestSeekRetrySeconds);
                 tracker.RetryForcedGoalPlanning();
             }
+        }
+
+        /// <summary>把逾時的休息點列入本輪黑名單並改選下一個；沒得選就原地小休。</summary>
+        private void FailOverToNextRestSpot(PathPlanningTracker tracker, AppConfig config, DateTime now)
+        {
+            if (_restSeekGoalNodeId != null)
+                _restSeekFailedNodeIds.Add(_restSeekGoalNodeId);
+
+            tracker.ClearForcedGoal();
+            _restSeekGoalNodeId = null;
+
+            var graph = tracker.NavGraph;
+            var playerPos = tracker.CurrentPathState?.CurrentPlayerPosition;
+            if (graph == null || playerPos == null)
+            {
+                BeginRestCountdown(config, now, "導航資料失效，原地小休");
+                return;
+            }
+
+            var selection = RestSpotSelector.Select(graph, playerPos.Value, _restSeekFailedNodeIds);
+            if (selection.Outcome != RestSpotOutcome.Found)
+            {
+                BeginRestCountdown(config, now, "所有休息點皆不可達，原地小休");
+                return;
+            }
+
+            Logger.Warning(
+                $"[休息尋點] 前往休息點逾時（>{RestSeekTimeoutSeconds}s），" +
+                $"改選 {selection.Node!.Id}（已排除 {_restSeekFailedNodeIds.Count} 個）");
+            BeginSeekingToward(tracker, selection.Node, now, "休息點逾時");
         }
 
         private void BeginRestCountdown(AppConfig config, DateTime now, string? reason)

--- a/Application/Pipeline/RestSpotSelector.cs
+++ b/Application/Pipeline/RestSpotSelector.cs
@@ -16,15 +16,19 @@ namespace ArtaleAI.Application.Pipeline
     /// <summary>
     /// 定時休息選點：安全折點與繩索同場比較，以 A* 路徑成本取最近「可達」者。
     /// 用圖上成本而非直線距離，避免挑到隔著斷層的假近點。
+    /// excludedNodeIds 供 Seeking 逾時後的故障轉移：本輪已證實到不了的點不再重選。
     /// </summary>
     public static class RestSpotSelector
     {
         private const float StartNodeSearchRadiusPx = 100f;
 
-        public static RestSpotSelection Select(NavigationGraph graph, PointF playerPos)
+        public static RestSpotSelection Select(
+            NavigationGraph graph,
+            PointF playerPos,
+            IReadOnlySet<string>? excludedNodeIds = null)
         {
             var candidates = graph.GetAllNodes()
-                .Where(IsRestCandidate)
+                .Where(node => IsRestCandidate(node) && excludedNodeIds?.Contains(node.Id) != true)
                 .ToList();
 
             if (candidates.Count == 0)

--- a/Domain/Navigation/MapGenerationService.cs
+++ b/Domain/Navigation/MapGenerationService.cs
@@ -97,20 +97,35 @@ namespace ArtaleAI.Domain.Navigation
                 if (string.Equals(fromId, toId, StringComparison.Ordinal))
                     continue;
 
-                bool duplicate = mapData.Edges.Any(e =>
-                    string.Equals(e.FromNodeId, fromId, StringComparison.Ordinal) &&
-                    string.Equals(e.ToNodeId, toId, StringComparison.Ordinal));
-                if (duplicate) continue;
+                TryAddDirectedManualEdge(mapData, nodeById, fromId, toId, anchor.ActionType);
 
-                float cost = ComputeAnchorCost(anchor, nodeById[fromId], nodeById[toId]);
-                mapData.Edges.Add(new NavEdgeData
-                {
-                    FromNodeId = fromId,
-                    ToNodeId = toId,
-                    ActionType = anchor.ActionType,
-                    Cost = cost
-                });
+                // SideJump 是兩平台間可站立落點的水平跳：能過去原則上能回來，
+                // 比照繩索／垂直跳點在拓撲層自動補反向，避免 A* 把回程當不可達。
+                if (anchor.ActionType == NavigationActionType.SideJump)
+                    TryAddDirectedManualEdge(mapData, nodeById, toId, fromId, NavigationActionType.SideJump);
             }
+        }
+
+        private static void TryAddDirectedManualEdge(
+            MapData mapData,
+            Dictionary<string, NavNodeData> nodeById,
+            string fromId,
+            string toId,
+            NavigationActionType actionType)
+        {
+            bool duplicate = mapData.Edges.Any(e =>
+                string.Equals(e.FromNodeId, fromId, StringComparison.Ordinal) &&
+                string.Equals(e.ToNodeId, toId, StringComparison.Ordinal));
+            if (duplicate) return;
+
+            float cost = ComputeActionCost(actionType, nodeById[fromId], nodeById[toId]);
+            mapData.Edges.Add(new NavEdgeData
+            {
+                FromNodeId = fromId,
+                ToNodeId = toId,
+                ActionType = actionType,
+                Cost = cost
+            });
         }
 
         /// <summary>
@@ -157,12 +172,12 @@ namespace ArtaleAI.Domain.Navigation
         }
 
         /// <summary>Cost 由 ActionType + 幾何距離決定，不由 UI 預算。</summary>
-        private static float ComputeAnchorCost(ManualEdgeAnchor anchor, NavNodeData from, NavNodeData to)
+        private static float ComputeActionCost(NavigationActionType actionType, NavNodeData from, NavNodeData to)
         {
             float dx = to.X - from.X;
             float dy = to.Y - from.Y;
             float dist = (float)Math.Sqrt(dx * dx + dy * dy);
-            return anchor.ActionType switch
+            return actionType switch
             {
                 NavigationActionType.Walk => dist,
                 NavigationActionType.Jump => Math.Max(JumpUpMinCost, dist * JumpUpCostPerPx),

--- a/Domain/Navigation/NavigationEdge.cs
+++ b/Domain/Navigation/NavigationEdge.cs
@@ -10,7 +10,7 @@ namespace ArtaleAI.Domain.Navigation
     {
         Walk = 1,
         Jump = 2,           // 手標跳躍；執行層依 ΔY 自動選原地/上跳或下跳
-        SideJump = 3,       // 側跳 (自動判定左右)
+        SideJump = 3,       // 側跳（自動判定左右；ManualEdge 拓撲自動雙向）
         JumpDown = 4,       // 下跳
         Teleport = 5,       // 傳送
         ClimbUp = 6,        // 繩索：下平台 → 上平台

--- a/MapData/ATTACK.json
+++ b/MapData/ATTACK.json
@@ -11,9 +11,9 @@
       97.2
     ],
     [
-      39.8,
-      106.0,
-      123.9
+      38.6,
+      105.9,
+      122.8
     ]
   ],
   "JumpLinks": [
@@ -53,9 +53,9 @@
       87.1
     ],
     [
-      40.0,
-      123.1,
-      131.2
+      38.5,
+      122.9,
+      130.7
     ]
   ],
   "PolylinePlatforms": [
@@ -234,6 +234,18 @@
       ]
     }
   ],
-  "ManualEdgeAnchors": [],
+  "ManualEdgeAnchors": [
+    {
+      "FromPlatformId": "plat_8",
+      "FromX": 148.8,
+      "FromY": 121.7,
+      "FromSegmentIndex": 0,
+      "ToPlatformId": "plat_7",
+      "ToX": 143.7,
+      "ToY": 117.6,
+      "ToSegmentIndex": 0,
+      "ActionType": 3
+    }
+  ],
   "RestrictedZones": []
 }

--- a/Models/Detection/MonsterDetectionCatalog.cs
+++ b/Models/Detection/MonsterDetectionCatalog.cs
@@ -1,20 +1,26 @@
 namespace ArtaleAI.Models.Detection
 {
-    /// <summary>執行期啟用的怪物模板集合；僅持有參考，生命週期由 <see cref="ArtaleAI.Vision.GameVisionCore"/> 快取管理。</summary>
+    /// <summary>
+    /// 執行期啟用的怪物模板集合；僅持有參考，生命週期由 <see cref="ArtaleAI.Vision.GameVisionCore"/> 快取管理。
+    /// UI 執行緒會在下載／重選怪物時改寫選擇，背景偵測執行緒同時列舉，
+    /// 故採「不可變快照 + 原子交換」：寫入端整組換掉陣列參考，讀取端永遠拿到一致版本，
+    /// 無鎖即可避免 Collection was modified。
+    /// </summary>
     public sealed class MonsterDetectionCatalog
     {
         /// <summary>程式硬上限；超過視為無效並截斷。</summary>
         public const int HardSelectLimit = 5;
 
-        private readonly List<MonsterTemplateBundle> _bundles = new();
+        private volatile MonsterTemplateBundle[] _bundles = Array.Empty<MonsterTemplateBundle>();
 
+        /// <summary>目前選擇的快照；取得後即使選擇被換掉，列舉仍安全。</summary>
         public IReadOnlyList<MonsterTemplateBundle> Bundles => _bundles;
 
-        public bool IsEmpty => _bundles.Count == 0 || _bundles.All(b => b.IsEmpty);
+        public bool IsEmpty => _bundles.Length == 0;
 
         public int TotalTemplateCount => _bundles.Sum(b => b.TemplateCount);
 
-        public int BundleCount => _bundles.Count;
+        public int BundleCount => _bundles.Length;
 
         public void SetSingle(MonsterTemplateBundle? bundle)
         {
@@ -30,18 +36,24 @@ namespace ArtaleAI.Models.Detection
         /// <summary>以多個 bundle 取代目前選擇；超過 <see cref="HardSelectLimit"/> 時截斷。</summary>
         public void SetMany(IEnumerable<MonsterTemplateBundle> bundles)
         {
-            Clear();
-            if (bundles == null) return;
+            if (bundles == null)
+            {
+                Clear();
+                return;
+            }
 
+            var next = new List<MonsterTemplateBundle>(HardSelectLimit);
             foreach (var bundle in bundles)
             {
                 if (bundle == null || bundle.IsEmpty) continue;
-                _bundles.Add(bundle);
-                if (_bundles.Count >= HardSelectLimit)
+                next.Add(bundle);
+                if (next.Count >= HardSelectLimit)
                     break;
             }
+
+            _bundles = next.ToArray();
         }
 
-        public void Clear() => _bundles.Clear();
+        public void Clear() => _bundles = Array.Empty<MonsterTemplateBundle>();
     }
 }

--- a/Models/Map/MapData.cs
+++ b/Models/Map/MapData.cs
@@ -34,7 +34,8 @@ namespace ArtaleAI.Models.Map
 
     /// <summary>
     /// 手動例外邊的幾何錨點。持久化語意為「在某平台的某個位置」，
-    /// 不綁定 runtime node ID，由 BuildHTopology.ResolveManualEdgeAnchors() 轉譯。
+    /// 不綁定 runtime node ID，由 MapGenerationService.ResolveManualEdgeAnchors 轉譯。
+    /// SideJump 會在拓撲層自動補反向邊；JumpDown／Teleport 維持單向。
     /// </summary>
     public class ManualEdgeAnchor
     {

--- a/UI/MapEditor/MapEditor.PropertyCommands.cs
+++ b/UI/MapEditor/MapEditor.PropertyCommands.cs
@@ -39,6 +39,8 @@ namespace ArtaleAI.UI.MapEditor
         public string? FromNodeId { get; init; }
         public string? ToNodeId { get; init; }
         public bool HasReverse { get; init; }
+        /// <summary>反向由 SideJump 拓撲自動補上，非使用者另畫的 ManualEdge。</summary>
+        public bool ReverseIsAuto { get; init; }
     }
 
     public partial class MapEditor
@@ -140,17 +142,22 @@ namespace ArtaleAI.UI.MapEditor
                 string.Equals(e.FromNodeId, fromNodeId, StringComparison.Ordinal) &&
                 string.Equals(e.ToNodeId, toNodeId, StringComparison.Ordinal));
 
-            bool hasReverse = _currentMapData.ManualEdgeAnchors?.Any(a =>
-                !ReferenceEquals(a, anchor) &&
-                string.Equals(a.FromPlatformId, anchor.ToPlatformId, StringComparison.Ordinal) &&
-                string.Equals(a.ToPlatformId, anchor.FromPlatformId, StringComparison.Ordinal)) == true;
+            bool hasReverse = anchor.ActionType == NavigationActionType.SideJump
+                || _currentMapData.Edges.Any(e =>
+                    string.Equals(e.FromNodeId, toNodeId, StringComparison.Ordinal) &&
+                    string.Equals(e.ToNodeId, fromNodeId, StringComparison.Ordinal))
+                || _currentMapData.ManualEdgeAnchors?.Any(a =>
+                    !ReferenceEquals(a, anchor) &&
+                    string.Equals(a.FromPlatformId, anchor.ToPlatformId, StringComparison.Ordinal) &&
+                    string.Equals(a.ToPlatformId, anchor.FromPlatformId, StringComparison.Ordinal)) == true;
 
             return new MapEditorManualEdgeStats
             {
                 Resolved = resolved,
                 FromNodeId = fromNodeId,
                 ToNodeId = toNodeId,
-                HasReverse = hasReverse
+                HasReverse = hasReverse,
+                ReverseIsAuto = anchor.ActionType == NavigationActionType.SideJump
             };
         }
 

--- a/UI/MapEditor/MapEditor.cs
+++ b/UI/MapEditor/MapEditor.cs
@@ -439,12 +439,22 @@ namespace ArtaleAI.UI.MapEditor
                 ? $"解析: 成功 → {fromNodeId} → {toNodeId}"
                 : "解析: 失敗（無對應 runtime 邊）");
 
-            bool hasReverse = _currentMapData.ManualEdgeAnchors?.Any(a =>
-                !ReferenceEquals(a, anchor) &&
-                string.Equals(a.FromPlatformId, anchor.ToPlatformId, StringComparison.Ordinal) &&
-                string.Equals(a.ToPlatformId, anchor.FromPlatformId, StringComparison.Ordinal)) == true;
+            if (anchor.ActionType == NavigationActionType.SideJump)
+            {
+                lines.Add("反向邊: SideJump 拓撲自動雙向");
+            }
+            else
+            {
+                bool hasReverse = _currentMapData.Edges.Any(e =>
+                        string.Equals(e.FromNodeId, toNodeId, StringComparison.Ordinal) &&
+                        string.Equals(e.ToNodeId, fromNodeId, StringComparison.Ordinal))
+                    || _currentMapData.ManualEdgeAnchors?.Any(a =>
+                        !ReferenceEquals(a, anchor) &&
+                        string.Equals(a.FromPlatformId, anchor.ToPlatformId, StringComparison.Ordinal) &&
+                        string.Equals(a.ToPlatformId, anchor.FromPlatformId, StringComparison.Ordinal)) == true;
 
-            lines.Add(hasReverse ? "反向邊: 已存在其他 ManualEdge" : "反向邊: 無（單向）");
+                lines.Add(hasReverse ? "反向邊: 已存在 runtime／ManualEdge" : "反向邊: 無（單向）");
+            }
         }
 
         private void AppendRuntimeNodeInspector(List<string> lines, int nodeIndex)

--- a/UI/MapEditor/MapEditorPropertyPanel.cs
+++ b/UI/MapEditor/MapEditorPropertyPanel.cs
@@ -389,10 +389,19 @@ namespace ArtaleAI.UI.MapEditor
             _content.Controls.Add(btnAction);
 
             AddRow(stats.Resolved ? "解析: 成功" : "解析: 失敗");
-            AddRow(stats.HasReverse ? "反向: 已有其他 ManualEdge" : "反向: 無（單向）");
+            AddRow(DescribeManualEdgeReverse(stats));
             AddCanvasGuide(
                 "移動錨點：刪除後用「兩點連線」在畫布重標",
                 "僅改動作類型：可用上方下拉（不需輸入座標）");
+        }
+
+        private static string DescribeManualEdgeReverse(MapEditorManualEdgeStats stats)
+        {
+            if (!stats.HasReverse)
+                return "反向: 無（單向）";
+            if (stats.ReverseIsAuto)
+                return "反向: SideJump 拓撲自動雙向";
+            return "反向: 已有其他 ManualEdge";
         }
 
         private void BuildRuntimeNodeView(MapEditor editor, int nodeIndex)


### PR DESCRIPTION
## Summary
- SideJump ManualEdge 在拓撲層自動補反向邊，避免 plat_7 等平台成為單向孤島導致 A* 失敗
- 休息尋點超過 45 秒未到達時，將該點列入本輪黑名單並改選其他安全區／繩索；候選耗盡才原地小休
- MonsterDetectionCatalog 改為 volatile 陣列原子交換，避免模板更新時 Collection was modified

## Test plan
- [ ] 重載 ATTACK 地圖後確認 SideJump 有雙向 runtime 邊
- [ ] 開啟自動打怪，跨過至少兩輪休息週期，確認能正常「前往休息點 → 小休 → 繼續打怪」
- [ ] 若日誌出現「休息點逾時」警告，確認會改選其他休息點而非永久卡住
- [ ] 掛機期間動態換怪物模板時不再出現 Collection was modified
