### PR TITLE
fix: low HP detection and safe retreat

### DIFF
--- a/Application/Console/ConsolePresenter.cs
+++ b/Application/Console/ConsolePresenter.cs
@@ -30,7 +30,9 @@ namespace ArtaleAI.Application.Console
                     : ConsoleStatusTone.Danger,
 
                 StatusCapture = FormatCapture(input),
-                StatusCaptureTone = input.IsResting || input.IsAvoidingOtherPlayers
+                StatusCaptureTone = input.IsResting
+                    || input.IsHealRetreating
+                    || input.IsAvoidingOtherPlayers
                     ? ConsoleStatusTone.Accent
                     : ConsoleStatusTone.Neutral,
 
@@ -73,6 +75,12 @@ namespace ArtaleAI.Application.Console
 
             if (input.IsRecoveringParty)
                 return "擷取：隊伍重建中";
+
+            if (input.IsSeekingHealSafeZone)
+                return "擷取：補給撤退中";
+
+            if (input.IsHealRetreating)
+                return "擷取：安全區回補中";
 
             if (input.IsSeekingRestSpot)
                 return "擷取：前往休息點";
@@ -118,6 +126,12 @@ namespace ArtaleAI.Application.Console
             if (input.IsRecoveringParty)
                 return "導航：隊伍重建";
 
+            if (input.IsSeekingHealSafeZone)
+                return "導航：補給撤退（安全區）";
+
+            if (input.IsHealRetreating)
+                return "導航：安全區等待回補";
+
             if (input.IsSeekingRestSpot)
                 return "導航：前往休息點（安全區/繩索）";
 
@@ -129,7 +143,10 @@ namespace ArtaleAI.Application.Console
 
         private static ConsoleStatusTone ResolveFsmTone(ConsoleStatusInput input)
         {
-            if (input.IsAvoidingOtherPlayers || input.IsRecoveringParty || input.IsResting)
+            if (input.IsAvoidingOtherPlayers
+                || input.IsRecoveringParty
+                || input.IsResting
+                || input.IsHealRetreating)
                 return ConsoleStatusTone.Accent;
 
             return input.FsmState == NavigationState.Error

--- a/Application/Console/ConsoleStatusInput.cs
+++ b/Application/Console/ConsoleStatusInput.cs
@@ -11,6 +11,10 @@ namespace ArtaleAI.Application.Console
         public bool IsResting { get; init; }
         /// <summary>休息流程的前段：正在前往安全區／繩索休息點（尚未開始倒數）。</summary>
         public bool IsSeekingRestSpot { get; init; }
+        /// <summary>補給無效後正在前往安全區或原地等待回補。</summary>
+        public bool IsHealRetreating { get; init; }
+        /// <summary>補給撤退前段：正在前往安全區。</summary>
+        public bool IsSeekingHealSafeZone { get; init; }
         public bool IsAvoidingOtherPlayers { get; init; }
         public NavigationState FsmState { get; init; } = NavigationState.Idle;
         public double? HpRatio { get; init; }

--- a/Application/Pipeline/AutoHealCoordinator.cs
+++ b/Application/Pipeline/AutoHealCoordinator.cs
@@ -4,15 +4,28 @@ using ArtaleAI.Shared;
 
 namespace ArtaleAI.Application.Pipeline
 {
+    public enum HealResourceKind
+    {
+        Hp,
+        Mp
+    }
+
+    /// <summary>補給效果判定後是否需撤退至安全區。</summary>
+    public readonly record struct HealRetreatSignal(
+        bool ShouldRetreat,
+        HealResourceKind? FailedResource);
+
     /// <summary>
-    /// 依血魔％決定是否按下藥水快捷鍵。不持有鍵盤；由 Pipeline 注入 tap 動作。
+    /// 依血魔％決定是否按下藥水快捷鍵，並追蹤「按了仍未回升」的連續失敗。
+    /// 不持有鍵盤；由 Pipeline 注入 tap 動作。
     /// </summary>
     public sealed class AutoHealCoordinator
     {
         private const int PulseHoldMs = 2000;
+        private const double PercentToRatio = 0.01;
 
-        private DateTime _lastHpHealUtc = DateTime.MinValue;
-        private DateTime _lastMpHealUtc = DateTime.MinValue;
+        private readonly ResourceWatch _hp = new();
+        private readonly ResourceWatch _mp = new();
         private DateTime _lastPulseUtc = DateTime.MinValue;
         private string _lastPulseLabel = string.Empty;
 
@@ -22,37 +35,79 @@ namespace ArtaleAI.Application.Pipeline
             DateTime nowUtc,
             Action<ushort> tapKey)
         {
+            _ = EvaluateAndHeal(settings, vitals, nowUtc, tapKey);
+        }
+
+        /// <summary>
+        /// 評估待觀察的補給效果、必要時按鍵，並在連續無效達標時回報撤退。
+        /// </summary>
+        public HealRetreatSignal EvaluateAndHeal(
+            AutoFarmSettings settings,
+            PlayerVitalsSnapshot? vitals,
+            DateTime nowUtc,
+            Action<ushort> tapKey)
+        {
             ArgumentNullException.ThrowIfNull(settings);
             ArgumentNullException.ThrowIfNull(tapKey);
 
             if (vitals?.HasFillReading != true)
-                return;
+                return default;
 
             int cooldownMs = Math.Clamp(settings.HealCooldownMs, 200, 5000);
+            int observeMs = Math.Max(cooldownMs, Math.Clamp(settings.HealObserveMs, 200, 10000));
+            double minRecovery = Math.Clamp(settings.HealMinRecoveryPercent, 1, 50) * PercentToRatio;
+            int failLimit = Math.Clamp(settings.HealFailureAttempts, 1, 10);
+
+            HealResourceKind? failed = null;
+
+            if (settings.HealHpEnabled)
+            {
+                TryResolveOutcome(
+                    _hp, vitals.HpRatio, vitals.ReadingId, nowUtc, minRecovery, failLimit, out bool hpFailed);
+                if (hpFailed || _hp.ConsecutiveFailures >= failLimit)
+                    failed = HealResourceKind.Hp;
+            }
+
+            if (settings.HealMpEnabled)
+            {
+                TryResolveOutcome(
+                    _mp, vitals.MpRatio, vitals.ReadingId, nowUtc, minRecovery, failLimit, out bool mpFailed);
+                if (failed == null && (mpFailed || _mp.ConsecutiveFailures >= failLimit))
+                    failed = HealResourceKind.Mp;
+            }
+
+            // 已達撤退門檻：停止再按，避免無效藥水空轉。
+            if (failed.HasValue)
+                return new HealRetreatSignal(true, failed);
+
             bool tappedHp = false;
             bool tappedMp = false;
 
             if (settings.HealHpEnabled)
             {
                 tappedHp = TryOne(
+                    _hp,
                     vitals.HpRatio,
+                    vitals.ReadingId,
                     settings.HealHpThresholdPercent,
                     settings.HealHpHotkey,
                     cooldownMs,
+                    observeMs,
                     nowUtc,
-                    ref _lastHpHealUtc,
                     tapKey);
             }
 
             if (settings.HealMpEnabled)
             {
                 tappedMp = TryOne(
+                    _mp,
                     vitals.MpRatio,
+                    vitals.ReadingId,
                     settings.HealMpThresholdPercent,
                     settings.HealMpHotkey,
                     cooldownMs,
+                    observeMs,
                     nowUtc,
-                    ref _lastMpHealUtc,
                     tapKey);
             }
 
@@ -66,6 +121,36 @@ namespace ArtaleAI.Application.Pipeline
                     _ => "剛補 MP"
                 };
             }
+
+            return default;
+        }
+
+        /// <summary>所有已啟用項目皆高於各自門檻（恢復打怪條件）。</summary>
+        public bool AreEnabledVitalsAboveThreshold(
+            AutoFarmSettings settings,
+            PlayerVitalsSnapshot? vitals)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+
+            if (vitals?.HasFillReading != true)
+                return false;
+
+            if (settings.HealHpEnabled
+                && IsBelowThreshold(vitals.HpRatio, settings.HealHpThresholdPercent))
+                return false;
+
+            if (settings.HealMpEnabled
+                && IsBelowThreshold(vitals.MpRatio, settings.HealMpThresholdPercent))
+                return false;
+
+            return settings.HealHpEnabled || settings.HealMpEnabled;
+        }
+
+        /// <summary>撤退解除或停止打怪時清掉失敗／觀察狀態，避免殘留觸發。</summary>
+        public void ClearFailureState()
+        {
+            _hp.ResetOutcome();
+            _mp.ResetOutcome();
         }
 
         /// <summary>StatusBar 短提示：剛按過鍵優先；否則顯示仍低於門檻但在冷卻中。</summary>
@@ -88,10 +173,10 @@ namespace ArtaleAI.Application.Pipeline
             int cooldownMs = Math.Clamp(settings.HealCooldownMs, 200, 5000);
             bool hpCooling = settings.HealHpEnabled
                 && IsBelowThreshold(vitals.HpRatio, settings.HealHpThresholdPercent)
-                && IsCoolingDown(nowUtc, _lastHpHealUtc, cooldownMs);
+                && IsCoolingDown(nowUtc, _hp.LastHealUtc, cooldownMs);
             bool mpCooling = settings.HealMpEnabled
                 && IsBelowThreshold(vitals.MpRatio, settings.HealMpThresholdPercent)
-                && IsCoolingDown(nowUtc, _lastMpHealUtc, cooldownMs);
+                && IsCoolingDown(nowUtc, _mp.LastHealUtc, cooldownMs);
 
             return (hpCooling, mpCooling) switch
             {
@@ -102,26 +187,74 @@ namespace ArtaleAI.Application.Pipeline
             };
         }
 
-        private static bool TryOne(
+        /// <summary>
+        /// 待觀察補給：必須等到觀察窗結束且出現比按鍵當下更新的 ReadingId。
+        /// 無新鮮讀值時不計失敗，避免偵測空窗誤判。
+        /// </summary>
+        private static void TryResolveOutcome(
+            ResourceWatch watch,
             double ratio,
+            long readingId,
+            DateTime nowUtc,
+            double minRecovery,
+            int failLimit,
+            out bool reachedFailLimit)
+        {
+            reachedFailLimit = watch.ConsecutiveFailures >= failLimit;
+            if (!watch.AwaitingOutcome)
+                return;
+
+            if (nowUtc < watch.ObserveUntilUtc)
+                return;
+
+            if (readingId <= watch.BaselineReadingId)
+                return;
+
+            watch.AwaitingOutcome = false;
+            double delta = ratio - watch.BaselineRatio;
+            if (delta >= minRecovery)
+            {
+                watch.ConsecutiveFailures = 0;
+                reachedFailLimit = false;
+                return;
+            }
+
+            watch.ConsecutiveFailures++;
+            reachedFailLimit = watch.ConsecutiveFailures >= failLimit;
+        }
+
+        private static bool TryOne(
+            ResourceWatch watch,
+            double ratio,
+            long readingId,
             int thresholdPercent,
             string? hotkey,
             int cooldownMs,
+            int observeMs,
             DateTime nowUtc,
-            ref DateTime lastHealUtc,
             Action<ushort> tapKey)
         {
-            if (!IsBelowThreshold(ratio, thresholdPercent))
+            if (watch.AwaitingOutcome)
                 return false;
 
-            if (IsCoolingDown(nowUtc, lastHealUtc, cooldownMs))
+            if (!IsBelowThreshold(ratio, thresholdPercent))
+            {
+                watch.ConsecutiveFailures = 0;
+                return false;
+            }
+
+            if (IsCoolingDown(nowUtc, watch.LastHealUtc, cooldownMs))
                 return false;
 
             if (!VirtualKeyParser.TryParse(hotkey, out ushort vk))
                 return false;
 
             tapKey(vk);
-            lastHealUtc = nowUtc;
+            watch.LastHealUtc = nowUtc;
+            watch.BaselineRatio = ratio;
+            watch.BaselineReadingId = readingId;
+            watch.ObserveUntilUtc = nowUtc.AddMilliseconds(observeMs);
+            watch.AwaitingOutcome = true;
             return true;
         }
 
@@ -135,5 +268,24 @@ namespace ArtaleAI.Application.Pipeline
         private static bool IsCoolingDown(DateTime nowUtc, DateTime lastHealUtc, int cooldownMs)
             => lastHealUtc != DateTime.MinValue
                && (nowUtc - lastHealUtc).TotalMilliseconds < cooldownMs;
+
+        private sealed class ResourceWatch
+        {
+            public DateTime LastHealUtc = DateTime.MinValue;
+            public double BaselineRatio;
+            public long BaselineReadingId;
+            public DateTime ObserveUntilUtc = DateTime.MinValue;
+            public int ConsecutiveFailures;
+            public bool AwaitingOutcome;
+
+            public void ResetOutcome()
+            {
+                AwaitingOutcome = false;
+                ConsecutiveFailures = 0;
+                BaselineRatio = 0;
+                BaselineReadingId = 0;
+                ObserveUntilUtc = DateTime.MinValue;
+            }
+        }
     }
 }

--- a/Application/Pipeline/GamePipeline.cs
+++ b/Application/Pipeline/GamePipeline.cs
@@ -60,6 +60,7 @@ namespace ArtaleAI.Application.Pipeline
         private DateTime _lastBloodBarDetection = DateTime.MinValue;
         private DateTime _lastPlayerVitalsDetection = DateTime.MinValue;
         private DateTime _lastMonsterDetection = DateTime.MinValue;
+        private long _nextVitalsReadingId;
 
         private volatile bool _isAttacking = false;
         private bool _lastAutoAttackEnabled;
@@ -89,6 +90,23 @@ namespace ArtaleAI.Application.Pipeline
         private DateTime _restSeekStartedUtc = DateTime.MinValue;
         private string? _restSeekGoalNodeId;
         private readonly HashSet<string> _restSeekFailedNodeIds = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// 補給失敗撤退：None=正常；Seeking=前往安全區（導航開放、攻擊關閉）；
+        /// Waiting=已到安全區等待血魔回升（導航與攻擊皆關閉）。
+        /// </summary>
+        private const int HealRetreatNone = 0;
+        private const int HealRetreatSeeking = 1;
+        private const int HealRetreatWaiting = 2;
+        private volatile int _healRetreatPhase = HealRetreatNone;
+
+        private const int HealRetreatSeekRetrySeconds = 3;
+        private const int HealRetreatSeekTimeoutSeconds = 45;
+        private DateTime _healRetreatSeekStartedUtc = DateTime.MinValue;
+        private DateTime _nextHealRetreatSeekRetryUtc = DateTime.MinValue;
+        private string? _healRetreatGoalNodeId;
+        private readonly HashSet<string> _healRetreatFailedNodeIds = new(StringComparer.Ordinal);
+
         private int _attackInputLease;
         private int _monsterDetectionInFlight;
         private int _monsterJobReplacementCount;
@@ -158,6 +176,12 @@ namespace ArtaleAI.Application.Pipeline
         /// <summary>正在前往安全折點／繩索休息點（導航仍開放）。</summary>
         public bool IsSeekingRestSpot => _restPhase == RestPhaseSeeking;
 
+        /// <summary>補給無效後的安全區撤退／等待回補中。</summary>
+        public bool IsHealRetreating => _healRetreatPhase != HealRetreatNone;
+
+        /// <summary>正在前往安全區（補給失敗撤退）。</summary>
+        public bool IsSeekingHealSafeZone => _healRetreatPhase == HealRetreatSeeking;
+
         /// <summary>小地圖遇人退避中。</summary>
         public bool IsAvoidingOtherPlayers => _otherPlayerAvoidance.IsAvoiding;
 
@@ -165,11 +189,12 @@ namespace ArtaleAI.Application.Pipeline
         public bool IsRecoveringParty => _partyRecovery.IsRecovering;
 
         /// <summary>
-        /// 攻擊／小休倒數／遇人退避／換頻／打怪清窗期間，導航 Walk 應讓出鍵盤。
-        /// SeekingRest 不在此列：前往休息點必須靠導航輸入。
+        /// 攻擊／小休倒數／補給等待／遇人退避／換頻／打怪清窗期間，導航 Walk 應讓出鍵盤。
+        /// SeekingRest／SeekingHealSafeZone 不在此列：前往目標必須靠導航輸入。
         /// </summary>
         public bool BlocksNavigationInput =>
             _restPhase == RestPhaseResting
+            || _healRetreatPhase == HealRetreatWaiting
             || _isAttacking
             || _otherPlayerAvoidance.IsAvoiding
             || _farmUiInterrupt.IsDismissing
@@ -285,8 +310,11 @@ namespace ArtaleAI.Application.Pipeline
 
                 TryProcessFarmUiInterrupt(frameMat, trackingResult, config);
 
-                if (AutoAttackEnabled)
+                if (AutoAttackEnabled && !IsHealRetreating)
                     ProcessAntiDetectRest(config, now);
+
+                if (IsHealRetreating)
+                    ProcessHealRetreat(config, now);
 
                 // 攻擊只允許從本入口發起；怪物背景 worker 僅更新結果，不得自行送鍵。
                 if (CanStartAttack())
@@ -407,6 +435,7 @@ namespace ArtaleAI.Application.Pipeline
         {
             return AutoAttackEnabled
                 && _restPhase == RestPhaseNone
+                && _healRetreatPhase == HealRetreatNone
                 && !_otherPlayerAvoidance.IsAvoiding
                 && !_partyRecovery.IsRecovering
                 && !_farmUiInterrupt.IsDismissing
@@ -414,10 +443,11 @@ namespace ArtaleAI.Application.Pipeline
                 && Volatile.Read(ref _attackInputLease) == 0;
         }
 
-        /// <summary>已持有攻擊租約時，換頻／退避發生則應立刻中止後續按鍵。</summary>
+        /// <summary>已持有攻擊租約時，換頻／退避／補給撤退發生則應立刻中止後續按鍵。</summary>
         private bool CanContinueAttack()
         {
             return AutoAttackEnabled
+                && _healRetreatPhase == HealRetreatNone
                 && !_otherPlayerAvoidance.IsAvoiding
                 && !_partyRecovery.IsRecovering
                 && !_farmUiInterrupt.IsDismissing
@@ -611,6 +641,8 @@ namespace ArtaleAI.Application.Pipeline
             _nextRestDueUtc = DateTime.MinValue;
             _nextRestSeekRetryUtc = DateTime.MinValue;
             CancelRestFlow();
+            CancelHealRetreatFlow(clearForcedGoal: true);
+            _autoHeal.ClearFailureState();
 
             AbortCombatInputs();
         }
@@ -915,11 +947,217 @@ namespace ArtaleAI.Application.Pipeline
             lock (_vitalsLock)
                 vitals = _currentPlayerVitals;
 
-            _autoHeal.TryHeal(
+            HealRetreatSignal signal = _autoHeal.EvaluateAndHeal(
                 config.AutoFarm,
                 vitals,
                 now,
                 TapSkillHotkey);
+
+            if (signal.ShouldRetreat && _healRetreatPhase == HealRetreatNone)
+            {
+                BeginHealRetreat(signal.FailedResource, now);
+                // 撤退狀態改由 Pipeline 持有；清掉失敗計數以便安全區內繼續喝水回補。
+                _autoHeal.ClearFailureState();
+            }
+        }
+
+        /// <summary>
+        /// 遇人換頻／隊伍重建進行中為更高優先；此時不推進撤退尋路逾時，避免誤判安全區不可達。
+        /// </summary>
+        private bool IsHealRetreatPreemptedByHigherPriority() =>
+            _otherPlayerAvoidance.IsAvoiding
+            || _partyRecovery.IsRecovering
+            || _farmUiInterrupt.IsDismissing
+            || Volatile.Read(ref _changeChannelInFlight) != 0;
+
+        private void BeginHealRetreat(HealResourceKind? failedResource, DateTime now)
+        {
+            CancelRestFlow();
+            AbortCombatInputs();
+
+            string label = failedResource switch
+            {
+                HealResourceKind.Hp => "HP",
+                HealResourceKind.Mp => "MP",
+                _ => "血魔"
+            };
+
+            _healRetreatFailedNodeIds.Clear();
+            _healRetreatGoalNodeId = null;
+            _nextHealRetreatSeekRetryUtc = DateTime.MinValue;
+            _healRetreatSeekStartedUtc = now;
+            _healRetreatPhase = HealRetreatSeeking;
+            OnStatusMessage?.Invoke($"{label} 連續補給無效，前往安全區…");
+
+            TryBeginHealRetreatSeek(now, announce: false);
+        }
+
+        private void CancelHealRetreatFlow(bool clearForcedGoal)
+        {
+            if (_healRetreatPhase == HealRetreatNone)
+                return;
+
+            _healRetreatPhase = HealRetreatNone;
+            _healRetreatGoalNodeId = null;
+            _healRetreatFailedNodeIds.Clear();
+            _healRetreatSeekStartedUtc = DateTime.MinValue;
+            _nextHealRetreatSeekRetryUtc = DateTime.MinValue;
+
+            if (clearForcedGoal)
+                RestNavigationTracker?.ClearForcedGoal();
+        }
+
+        private void ProcessHealRetreat(AppConfig config, DateTime now)
+        {
+            if (_healRetreatPhase == HealRetreatWaiting)
+            {
+                ProcessHealRetreatWaiting(config, now);
+                return;
+            }
+
+            if (_healRetreatPhase != HealRetreatSeeking)
+                return;
+
+            if (IsHealRetreatPreemptedByHigherPriority())
+                return;
+
+            var tracker = RestNavigationTracker;
+            if (tracker == null)
+            {
+                EnterHealRetreatWaiting("無導航資料，原地等待回補");
+                return;
+            }
+
+            if (tracker.HasForcedGoal && tracker.IsForcedGoalArrived)
+            {
+                EnterHealRetreatWaiting(reason: null);
+                return;
+            }
+
+            if (!tracker.HasForcedGoal)
+            {
+                TryBeginHealRetreatSeek(now, announce: true);
+                return;
+            }
+
+            if ((now - _healRetreatSeekStartedUtc).TotalSeconds > HealRetreatSeekTimeoutSeconds)
+            {
+                FailOverHealRetreatSpot(tracker, now);
+                return;
+            }
+
+            if (tracker.IsForcedGoalPlanningParked && now >= _nextHealRetreatSeekRetryUtc)
+            {
+                _nextHealRetreatSeekRetryUtc = now.AddSeconds(HealRetreatSeekRetrySeconds);
+                tracker.RetryForcedGoalPlanning();
+            }
+        }
+
+        private void ProcessHealRetreatWaiting(AppConfig config, DateTime now)
+        {
+            PlayerVitalsSnapshot? vitals;
+            lock (_vitalsLock)
+                vitals = _currentPlayerVitals;
+
+            if (!_autoHeal.AreEnabledVitalsAboveThreshold(config.AutoFarm, vitals))
+                return;
+
+            RestNavigationTracker?.ClearForcedGoal();
+            CancelHealRetreatFlow(clearForcedGoal: false);
+            _autoHeal.ClearFailureState();
+            OnStatusMessage?.Invoke("血魔已回補，繼續自動打怪");
+        }
+
+        private void EnterHealRetreatWaiting(string? reason)
+        {
+            _healRetreatPhase = HealRetreatWaiting;
+            _movementController?.StopMovement();
+            OnStatusMessage?.Invoke(reason ?? "已到安全區，等待血魔回補…");
+        }
+
+        private void TryBeginHealRetreatSeek(DateTime now, bool announce)
+        {
+            if (now < _nextHealRetreatSeekRetryUtc)
+                return;
+
+            var tracker = RestNavigationTracker;
+            var graph = tracker?.NavGraph;
+            var playerPos = tracker?.CurrentPathState?.CurrentPlayerPosition;
+
+            if (tracker == null || graph == null || playerPos == null)
+            {
+                EnterHealRetreatWaiting("無導航資料，原地等待回補");
+                return;
+            }
+
+            var selection = RestSpotSelector.Select(
+                graph,
+                playerPos.Value,
+                _healRetreatFailedNodeIds,
+                RestSpotCandidateMode.SafeZonesOnly);
+
+            switch (selection.Outcome)
+            {
+                case RestSpotOutcome.NoCandidates:
+                    EnterHealRetreatWaiting("地圖無安全區，原地等待回補");
+                    return;
+
+                case RestSpotOutcome.Unreachable:
+                    _nextHealRetreatSeekRetryUtc = now.AddSeconds(HealRetreatSeekRetrySeconds);
+                    if (announce)
+                        OnStatusMessage?.Invoke("安全區暫時不可達，稍後重試…");
+                    return;
+            }
+
+            BeginHealRetreatSeekingToward(tracker, selection.Node!, now, announce);
+        }
+
+        private void BeginHealRetreatSeekingToward(
+            PathPlanningTracker tracker,
+            NavigationNode spot,
+            DateTime now,
+            bool announce)
+        {
+            tracker.SetForcedGoal(spot.Id);
+            _healRetreatGoalNodeId = spot.Id;
+            _healRetreatSeekStartedUtc = now;
+            _healRetreatPhase = HealRetreatSeeking;
+            if (announce)
+                OnStatusMessage?.Invoke("補給失敗，前往安全區…");
+        }
+
+        private void FailOverHealRetreatSpot(PathPlanningTracker tracker, DateTime now)
+        {
+            if (_healRetreatGoalNodeId != null)
+                _healRetreatFailedNodeIds.Add(_healRetreatGoalNodeId);
+
+            tracker.ClearForcedGoal();
+            _healRetreatGoalNodeId = null;
+
+            var graph = tracker.NavGraph;
+            var playerPos = tracker.CurrentPathState?.CurrentPlayerPosition;
+            if (graph == null || playerPos == null)
+            {
+                EnterHealRetreatWaiting("導航資料失效，原地等待回補");
+                return;
+            }
+
+            var selection = RestSpotSelector.Select(
+                graph,
+                playerPos.Value,
+                _healRetreatFailedNodeIds,
+                RestSpotCandidateMode.SafeZonesOnly);
+
+            if (selection.Outcome != RestSpotOutcome.Found)
+            {
+                EnterHealRetreatWaiting("所有安全區皆不可達，原地等待回補");
+                return;
+            }
+
+            Logger.Warning(
+                $"[補給撤退] 前往安全區逾時（>{HealRetreatSeekTimeoutSeconds}s），" +
+                $"改選 {selection.Node!.Id}（已排除 {_healRetreatFailedNodeIds.Count} 個）");
+            BeginHealRetreatSeekingToward(tracker, selection.Node, now, announce: true);
         }
 
         private void ProcessBuffSkills(AppConfig config, DateTime now)
@@ -1209,11 +1447,17 @@ namespace ArtaleAI.Application.Pipeline
 
                 if (measured.HasFillReading)
                 {
+                    long readingId = Interlocked.Increment(ref _nextVitalsReadingId);
                     lock (_vitalsLock)
                     {
+                        var stamped = measured with
+                        {
+                            ReadingId = readingId,
+                            MeasuredAtUtc = now
+                        };
                         snapshot = vitalsSettings.SmoothReadings
-                            ? SmoothVitals(measured, _currentPlayerVitals, vitalsSettings.EmaAlpha)
-                            : measured;
+                            ? SmoothVitals(stamped, _currentPlayerVitals, vitalsSettings.EmaAlpha)
+                            : stamped;
                         _currentPlayerVitals = snapshot;
                     }
                     _lastPlayerVitalsDetection = now;
@@ -1243,7 +1487,9 @@ namespace ArtaleAI.Application.Pipeline
             return raw with
             {
                 HpRatio = SmoothRatio(raw.HpRatio, previous.HpRatio, alpha, snapDelta),
-                MpRatio = SmoothRatio(raw.MpRatio, previous.MpRatio, alpha, snapDelta)
+                MpRatio = SmoothRatio(raw.MpRatio, previous.MpRatio, alpha, snapDelta),
+                ReadingId = raw.ReadingId,
+                MeasuredAtUtc = raw.MeasuredAtUtc
             };
         }
 

--- a/Application/Pipeline/RestSpotSelector.cs
+++ b/Application/Pipeline/RestSpotSelector.cs
@@ -11,10 +11,19 @@ namespace ArtaleAI.Application.Pipeline
         Unreachable
     }
 
+    /// <summary>
+    /// 候選範圍：定時休息含繩索；補給失敗撤退只允許地圖標記的安全區。
+    /// </summary>
+    public enum RestSpotCandidateMode
+    {
+        SafeZonesAndRopes,
+        SafeZonesOnly
+    }
+
     public readonly record struct RestSpotSelection(RestSpotOutcome Outcome, NavigationNode? Node);
 
     /// <summary>
-    /// 定時休息選點：安全折點與繩索同場比較，以 A* 路徑成本取最近「可達」者。
+    /// 定時休息／緊急撤退選點：以 A* 路徑成本取最近「可達」者。
     /// 用圖上成本而非直線距離，避免挑到隔著斷層的假近點。
     /// excludedNodeIds 供 Seeking 逾時後的故障轉移：本輪已證實到不了的點不再重選。
     /// </summary>
@@ -25,10 +34,11 @@ namespace ArtaleAI.Application.Pipeline
         public static RestSpotSelection Select(
             NavigationGraph graph,
             PointF playerPos,
-            IReadOnlySet<string>? excludedNodeIds = null)
+            IReadOnlySet<string>? excludedNodeIds = null,
+            RestSpotCandidateMode mode = RestSpotCandidateMode.SafeZonesAndRopes)
         {
             var candidates = graph.GetAllNodes()
-                .Where(node => IsRestCandidate(node) && excludedNodeIds?.Contains(node.Id) != true)
+                .Where(node => IsCandidate(node, mode) && excludedNodeIds?.Contains(node.Id) != true)
                 .ToList();
 
             if (candidates.Count == 0)
@@ -62,8 +72,14 @@ namespace ArtaleAI.Application.Pipeline
                 : new(RestSpotOutcome.Found, best);
         }
 
-        private static bool IsRestCandidate(NavigationNode node) =>
-            (node.Type == NavigationNodeType.Platform && node.IsSafeZone)
-            || node.Type == NavigationNodeType.Rope;
+        private static bool IsCandidate(NavigationNode node, RestSpotCandidateMode mode) =>
+            mode switch
+            {
+                RestSpotCandidateMode.SafeZonesOnly =>
+                    node.Type == NavigationNodeType.Platform && node.IsSafeZone,
+                _ =>
+                    (node.Type == NavigationNodeType.Platform && node.IsSafeZone)
+                    || node.Type == NavigationNodeType.Rope
+            };
     }
 }

--- a/ArtaleAI.csproj
+++ b/ArtaleAI.csproj
@@ -14,6 +14,9 @@
     <Compile Remove="MapData\**" />
     <EmbeddedResource Remove="MapData\**" />
     <Page Remove="MapData\**" />
+    <Compile Remove="Tests\**" />
+    <EmbeddedResource Remove="Tests\**" />
+    <None Remove="Tests\**" />
   </ItemGroup>
 
   <!-- 執行期內容：複製到輸出目錄（PathManager 優先讀專案根；找不到 csproj 時仍可從 bin 讀取） -->

--- a/Data/config.yaml
+++ b/Data/config.yaml
@@ -195,6 +195,9 @@ autoFarm:
   healMpThresholdPercent: 30
   healMpHotkey: Insert
   healCooldownMs: 800
+  healFailureAttempts: 3
+  healMinRecoveryPercent: 3
+  healObserveMs: 800
   buffSkills:
   - enabled: false
     hotkey: F1

--- a/Models/Config/AutoFarmSettings.cs
+++ b/Models/Config/AutoFarmSettings.cs
@@ -31,6 +31,21 @@ namespace ArtaleAI.Models.Config
         /// <summary>同類型藥水最短間隔，避免連按。</summary>
         public int HealCooldownMs { get; set; } = 800;
 
+        /// <summary>
+        /// 連續補給無效次數達標後撤退至安全區。
+        /// 「無效」＝觀察窗結束且新鮮讀值回升幅度低於 <see cref="HealMinRecoveryPercent"/>。
+        /// </summary>
+        public int HealFailureAttempts { get; set; } = 3;
+
+        /// <summary>判定補給有效的最低回升百分比（相對按鍵前讀值）。</summary>
+        public int HealMinRecoveryPercent { get; set; } = 3;
+
+        /// <summary>
+        /// 按鍵後最短觀察毫秒；實際觀察窗取 max(本值, HealCooldownMs)。
+        /// 需等到新的 vitals ReadingId 才結算，避免同幀重算。
+        /// </summary>
+        public int HealObserveMs { get; set; } = 800;
+
         /// <summary>補助技能固定槽位數（UI／YAML／Coordinator 共用）。</summary>
         public const int MaxBuffSkillSlots = 5;
 

--- a/Models/Config/VisionSettings.cs
+++ b/Models/Config/VisionSettings.cs
@@ -112,7 +112,10 @@ namespace ArtaleAI.Models.Config
         /// </summary>
         public double BloodBarFrameMaxInteriorTip { get; set; } = 0.12;
 
-        /// <summary>紅填充最小長寬比（擋方形活動 ICON 紅塊）。</summary>
+        /// <summary>
+        /// 紅填充最小長寬比（擋方形活動 ICON）。
+        /// 僅在填充寬度 ≥ 高×此值時套用；更短的低血紅條不套用，改靠高度與端點。
+        /// </summary>
         public double BloodBarFrameMinFillAspect { get; set; } = 2.5;
 
         /// <summary>上一幀外框追蹤半徑（像素）；候選中心在此距離內加分。</summary>

--- a/Models/Detection/PlayerVitalsSnapshot.cs
+++ b/Models/Detection/PlayerVitalsSnapshot.cs
@@ -19,6 +19,15 @@ namespace ArtaleAI.Models.Detection
         /// <summary>HSV 填充率讀取成功（與 ROI 校準可獨立）。</summary>
         public bool HasFillReading { get; init; }
 
+        /// <summary>
+        /// 每次成功量測填充率時遞增；佈局-only 更新不改動。
+        /// 補給效果判定只消費更新的 ReadingId，避免同幀重算失敗。
+        /// </summary>
+        public long ReadingId { get; init; }
+
+        /// <summary>本次填充量測的 UTC 時間；無填充讀數時為 MinValue。</summary>
+        public DateTime MeasuredAtUtc { get; init; }
+
         public static PlayerVitalsSnapshot Empty { get; } = new();
     }
 }

--- a/Tests/ArtaleAI.Tests.csproj
+++ b/Tests/ArtaleAI.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- 不引用 WinExe／WinAppSDK 主專案，改連結純邏輯原始碼，避免 MSIX/PRI 建置污染。 -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Application\Pipeline\AutoHealCoordinator.cs" Link="Linked\AutoHealCoordinator.cs" />
+    <Compile Include="..\Models\Config\AutoFarmSettings.cs" Link="Linked\AutoFarmSettings.cs" />
+    <Compile Include="..\Models\Config\BuffSkillEntry.cs" Link="Linked\BuffSkillEntry.cs" />
+    <Compile Include="..\Models\Config\AttackSkillEntry.cs" Link="Linked\AttackSkillEntry.cs" />
+    <Compile Include="..\Models\Config\ChannelPickGridSettings.cs" Link="Linked\ChannelPickGridSettings.cs" />
+    <Compile Include="..\Models\Detection\PlayerVitalsSnapshot.cs" Link="Linked\PlayerVitalsSnapshot.cs" />
+    <Compile Include="..\Shared\VirtualKeyParser.cs" Link="Linked\VirtualKeyParser.cs" />
+  </ItemGroup>
+</Project>

--- a/Tests/AutoHealCoordinatorTests.cs
+++ b/Tests/AutoHealCoordinatorTests.cs
@@ -1,0 +1,176 @@
+using ArtaleAI.Application.Pipeline;
+using ArtaleAI.Models.Config;
+using ArtaleAI.Models.Detection;
+using Xunit;
+
+namespace ArtaleAI.Tests;
+
+public sealed class AutoHealCoordinatorTests
+{
+    [Fact]
+    public void SuccessfulRecovery_ClearsFailureCount()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: false);
+        int taps = 0;
+
+        Assert.False(sut.EvaluateAndHeal(settings, Snapshot(0.30, 1.0, 1), Utc(0), _ => taps++).ShouldRetreat);
+        Assert.Equal(1, taps);
+
+        // 回升 10%：視為有效，失敗計數清零
+        Assert.False(sut.EvaluateAndHeal(settings, Snapshot(0.40, 1.0, 2), Utc(1000), _ => taps++).ShouldRetreat);
+
+        // 再次掉血應可再按（不是被舊失敗卡住）
+        Assert.False(sut.EvaluateAndHeal(settings, Snapshot(0.30, 1.0, 3), Utc(2000), _ => taps++).ShouldRetreat);
+        Assert.Equal(2, taps);
+    }
+
+    [Fact]
+    public void ThreeFailedHpHeals_TriggersRetreat()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: false);
+        int taps = 0;
+        HealRetreatSignal signal = default;
+
+        // 每次：新讀值結算上一次失敗後，若仍低於門檻會立刻再按
+        // t0 id1: tap#1
+        // t1000 id2: fail1 + tap#2
+        // t2000 id3: fail2 + tap#3
+        // t3000 id4: fail3 → 撤退
+        long readingId = 1;
+        for (int step = 0; step < 4; step++)
+        {
+            signal = sut.EvaluateAndHeal(
+                settings,
+                Snapshot(0.30, 1.0, readingId++),
+                Utc(step * 1000),
+                _ => taps++);
+        }
+
+        Assert.Equal(3, taps);
+        Assert.True(signal.ShouldRetreat);
+        Assert.Equal(HealResourceKind.Hp, signal.FailedResource);
+    }
+
+    [Fact]
+    public void HpAndMpFailures_AreIndependent()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: true);
+        int taps = 0;
+
+        // MP 維持高於門檻，只有 HP 累積失敗
+        HealRetreatSignal signal = default;
+        long readingId = 1;
+        for (int step = 0; step < 4; step++)
+        {
+            signal = sut.EvaluateAndHeal(
+                settings,
+                Snapshot(0.30, 0.90, readingId++),
+                Utc(step * 1000),
+                _ => taps++);
+        }
+
+        Assert.True(signal.ShouldRetreat);
+        Assert.Equal(HealResourceKind.Hp, signal.FailedResource);
+        Assert.Equal(3, taps);
+    }
+
+    [Fact]
+    public void SameReadingId_DoesNotCountAsFailure()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: false);
+        int taps = 0;
+
+        Assert.False(sut.EvaluateAndHeal(settings, Snapshot(0.30, 1.0, 1), Utc(0), _ => taps++).ShouldRetreat);
+        Assert.Equal(1, taps);
+
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.False(sut.EvaluateAndHeal(
+                settings,
+                Snapshot(0.30, 1.0, 1),
+                Utc(1000 + i * 100),
+                _ => taps++).ShouldRetreat);
+        }
+
+        Assert.Equal(1, taps);
+    }
+
+    [Fact]
+    public void AreEnabledVitalsAboveThreshold_RequiresAllEnabled()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: true);
+
+        Assert.False(sut.AreEnabledVitalsAboveThreshold(settings, Snapshot(0.50, 0.20, 1)));
+        Assert.False(sut.AreEnabledVitalsAboveThreshold(settings, Snapshot(0.20, 0.50, 2)));
+        Assert.True(sut.AreEnabledVitalsAboveThreshold(settings, Snapshot(0.50, 0.50, 3)));
+    }
+
+    [Fact]
+    public void DisabledResource_IsIgnoredForRecovery()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: false);
+
+        Assert.True(sut.AreEnabledVitalsAboveThreshold(settings, Snapshot(0.50, 0.05, 1)));
+    }
+
+    [Fact]
+    public void ClearFailureState_AllowsFreshAttemptsAfterRetreat()
+    {
+        var sut = new AutoHealCoordinator();
+        var settings = CreateSettings(hpEnabled: true, mpEnabled: false);
+        int taps = 0;
+
+        long readingId = 1;
+        for (int step = 0; step < 4; step++)
+        {
+            sut.EvaluateAndHeal(settings, Snapshot(0.30, 1.0, readingId++), Utc(step * 1000), _ => taps++);
+        }
+
+        Assert.Equal(3, taps);
+        sut.ClearFailureState();
+
+        var signal = sut.EvaluateAndHeal(
+            settings,
+            Snapshot(0.30, 1.0, readingId),
+            Utc(10000),
+            _ => taps++);
+
+        Assert.False(signal.ShouldRetreat);
+        Assert.Equal(4, taps);
+    }
+
+    private static AutoFarmSettings CreateSettings(bool hpEnabled, bool mpEnabled) =>
+        new()
+        {
+            HealHpEnabled = hpEnabled,
+            HealHpThresholdPercent = 40,
+            HealHpHotkey = "Insert",
+            HealMpEnabled = mpEnabled,
+            HealMpThresholdPercent = 30,
+            HealMpHotkey = "Delete",
+            HealCooldownMs = 800,
+            HealFailureAttempts = 3,
+            HealMinRecoveryPercent = 3,
+            HealObserveMs = 800
+        };
+
+    private static PlayerVitalsSnapshot Snapshot(double hp, double mp, long readingId) =>
+        new()
+        {
+            HpRatio = hp,
+            MpRatio = mp,
+            HasFillReading = true,
+            IsLayoutValid = true,
+            ReadingId = readingId,
+            MeasuredAtUtc = DateTime.UtcNow
+        };
+
+    private static DateTime Utc(int ms) =>
+        new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(ms);
+}

--- a/UI/MainForm.Console.cs
+++ b/UI/MainForm.Console.cs
@@ -682,6 +682,8 @@ namespace ArtaleAI
                 CaptureRunning = liveViewManager?.IsRunning == true,
                 IsResting = _gamePipeline?.IsResting == true,
                 IsSeekingRestSpot = _gamePipeline?.IsSeekingRestSpot == true,
+                IsHealRetreating = _gamePipeline?.IsHealRetreating == true,
+                IsSeekingHealSafeZone = _gamePipeline?.IsSeekingHealSafeZone == true,
                 IsAvoidingOtherPlayers = _gamePipeline?.IsAvoidingOtherPlayers == true,
                 IsRecoveringParty = _gamePipeline?.IsRecoveringParty == true,
                 FsmState = _fsm?.CurrentState ?? NavigationState.Idle,

--- a/Vision/GameVisionCore.BloodBar.cs
+++ b/Vision/GameVisionCore.BloodBar.cs
@@ -250,10 +250,16 @@ namespace ArtaleAI.Vision
                         br.Height < minFillH || br.Height > maxFillH)
                         continue;
 
-                    // 活動 ICON 紅塊偏方；真血條填充必須是橫長條
-                    double aspect = br.Width / (double)Math.Max(1, br.Height);
-                    if (aspect < minFillAspect)
-                        continue;
+                    // 長寬比只擋「夠寬才看得出是橫條」的候選。
+                    // 低血短紅條寬度小、比例必然偏低；若硬套用會在約 1/3 血以下冷啟漏檢，
+                    // 誤觸發隊伍重建。短紅條改由高度閘門 + 左右端點括號把關。
+                    int aspectGateMinWidth = (int)Math.Ceiling(frameH * minFillAspect);
+                    if (br.Width >= aspectGateMinWidth)
+                    {
+                        double aspect = br.Width / (double)Math.Max(1, br.Height);
+                        if (aspect < minFillAspect)
+                            continue;
+                    }
 
                     fillCount++;
 


### PR DESCRIPTION
修正低血短紅條被長寬比閘門誤殺，並在 HP/MP 連續三次補給無效時撤退至安全區。所有已啟用血魔恢復至門檻後才恢復打怪。驗證：7 個單元測試通過，主專案建置 0 警告 0 錯誤。

Made with [Cursor](https://cursor.com)