### PR TITLE
fix(nav): 掛繩先離繩並強化攻擊／導航輸入協調

### DIFF
--- a/Application/Navigation/NavigationExecutor.cs
+++ b/Application/Navigation/NavigationExecutor.cs
@@ -235,7 +235,14 @@ namespace ArtaleAI.Application.Navigation
 
             _movementController.FocusGameWindow();
 
-            _keyboard.HoldKey(VK_DOWN);
+            // 攻擊租約佔鍵時 HoldKey 會失敗；不可忽略後仍送 Alt（假下跳 → 假卡點 → 熔斷）。
+            if (!_keyboard.HoldKey(VK_DOWN))
+            {
+                Logger.Warning("[下跳] 無法按住 ↓（導航輸入被更高優先活動佔用），判定失敗並交回救援。");
+                _keyboard.SendKey(VK_DOWN, true);
+                return ExecutionResult.Failed;
+            }
+
             await Task.Delay(JumpDownDirectionLeadMs, ct);
 
             _keyboard.SendKey(VK_JUMP, false);

--- a/Application/Navigation/PathPlanningManager.cs
+++ b/Application/Navigation/PathPlanningManager.cs
@@ -43,12 +43,14 @@ namespace ArtaleAI.Application.Navigation
             if (captureItem == null)
                 throw new InvalidOperationException($"無法找到遊戲視窗: {gameWindowTitle}");
 
+            // 每次開打怪都清熔斷／Approach 黑名單，否則關過再開會被舊狀態擋死。
+            _tracker.ResetFarmSessionState();
             _isRunning = true;
             Logger.Info("[路徑規劃管理] 路徑規劃已啟動");
             return Task.CompletedTask;
         }
 
-        /// <summary>清除運行旗標。</summary>
+        /// <summary>清除運行旗標，並重置打怪工作階段殘留狀態。</summary>
         public Task StopAsync()
         {
             if (!_isRunning)
@@ -58,6 +60,7 @@ namespace ArtaleAI.Application.Navigation
             }
 
             _isRunning = false;
+            _tracker.ResetFarmSessionState();
             Logger.Info("[路徑規劃管理] 路徑規劃已停止");
             return Task.CompletedTask;
         }

--- a/Application/Pipeline/AttackInputArbiter.cs
+++ b/Application/Pipeline/AttackInputArbiter.cs
@@ -1,0 +1,42 @@
+namespace ArtaleAI.Application.Pipeline
+{
+    /// <summary>
+    /// 攻擊與導航共享鍵盤時的仲裁規則（純決策，不持有鍵）。
+    /// 楓之谷主攻為長按連打；輪轉技仍採單次脈衝。
+    /// </summary>
+    public static class AttackInputArbiter
+    {
+        /// <summary>放開攻擊鍵後，再次取得租約前的最短間隔（防抖）。</summary>
+        public const int SessionCooldownMs = 150;
+
+        /// <summary>面向重點最短間隔，減少同方向重複 tap。</summary>
+        public const int DirectionChangeCooldownMs = 200;
+
+        /// <summary>輪轉技等單次脈衝的按下時間。</summary>
+        public const int SkillPulseMs = 35;
+
+        /// <summary>長按主攻時，重驗目標與中斷條件的輪詢間隔。</summary>
+        public const int HoldPollMs = 50;
+
+        /// <summary>長按安全上限，避免偵測異常時攻擊鍵永遠不放開。</summary>
+        public const int MaxHoldMs = 4000;
+
+        public static bool IsCooldownReady(DateTime lastSessionEndUtc, DateTime nowUtc, int cooldownMs = SessionCooldownMs)
+        {
+            if (lastSessionEndUtc == DateTime.MinValue)
+                return true;
+
+            int gate = cooldownMs > 0 ? cooldownMs : SessionCooldownMs;
+            return (nowUtc - lastSessionEndUtc).TotalMilliseconds >= gate;
+        }
+
+        public static bool ShouldRetapFacing(
+            DateTime lastFacingUtc,
+            DateTime nowUtc,
+            int cooldownMs = DirectionChangeCooldownMs)
+        {
+            int gate = cooldownMs > 0 ? cooldownMs : DirectionChangeCooldownMs;
+            return (nowUtc - lastFacingUtc).TotalMilliseconds > gate;
+        }
+    }
+}

--- a/Application/Pipeline/AttackRotationCoordinator.cs
+++ b/Application/Pipeline/AttackRotationCoordinator.cs
@@ -21,14 +21,17 @@ namespace ArtaleAI.Application.Pipeline
         private readonly Random _random = new();
 
         /// <summary>選出本次攻擊 Virtual-Key；無法解析主攻則失敗。</summary>
+        /// <param name="useHoldAttack">true＝主攻長按連打；false＝輪轉技單次脈衝。</param>
         public bool TrySelectAttackKey(
             AutoFarmSettings settings,
             DateTime nowUtc,
             out ushort virtualKey,
-            out string displayLabel)
+            out string displayLabel,
+            out bool useHoldAttack)
         {
             virtualKey = 0;
             displayLabel = string.Empty;
+            useHoldAttack = false;
             ArgumentNullException.ThrowIfNull(settings);
 
             settings.EnsureAttackSkillSlots();
@@ -49,6 +52,7 @@ namespace ArtaleAI.Application.Pipeline
 
                 virtualKey = skillVk;
                 displayLabel = NormalizeLabel(skill.Hotkey);
+                useHoldAttack = false;
                 _nextReadyUtc[i] = nowUtc.AddSeconds(ResolveCooldownSeconds(skill.CooldownSeconds));
                 _lastPulseUtc = nowUtc;
                 _lastPulseLabel = $"攻擊技 {displayLabel}";
@@ -59,6 +63,7 @@ namespace ArtaleAI.Application.Pipeline
                 return false;
 
             displayLabel = NormalizeLabel(settings.AttackPrimaryHotkey);
+            useHoldAttack = true;
             return true;
         }
 

--- a/Application/Pipeline/GamePipeline.cs
+++ b/Application/Pipeline/GamePipeline.cs
@@ -115,8 +115,7 @@ namespace ArtaleAI.Application.Pipeline
         private const int MonsterJobReplacementLogInterval = 30;
         private DateTime _lastAttackTime = DateTime.MinValue;
         private DateTime _lastDirectionChangeTime = DateTime.MinValue;
-        private const int AttackCooldownMs = 500;
-        private const int DirectionChangeCooldownMs = 200;
+        private int _heldAttackVirtualKey;
         private const ushort VK_LEFT = 0x25;
         private const ushort VK_RIGHT = 0x27;
         private const ushort VK_CONTROL = 0x11;
@@ -189,7 +188,8 @@ namespace ArtaleAI.Application.Pipeline
         public bool IsRecoveringParty => _partyRecovery.IsRecovering;
 
         /// <summary>
-        /// 攻擊／小休倒數／補給等待／遇人退避／換頻／打怪清窗期間，導航 Walk 應讓出鍵盤。
+        /// 攻擊／小休倒數／補給等待／遇人退避／換頻／打怪清窗期間，移動控制器應讓出方向鍵。
+        /// 導航 FSM 仍應持續 tick（由 MovementController 在送鍵前讓路），不可連編排一起擋住。
         /// SeekingRest／SeekingHealSafeZone 不在此列：前往目標必須靠導航輸入。
         /// </summary>
         public bool BlocksNavigationInput =>
@@ -316,11 +316,16 @@ namespace ArtaleAI.Application.Pipeline
                 if (IsHealRetreating)
                     ProcessHealRetreat(config, now);
 
+                // 垂直換層優先於長按攻擊：先搶回鍵盤，再允許導航送 ↓／Alt。
+                if (ShouldDeferAttackForNavigation() && IsCombatInputHeld())
+                    PreemptCombatForNavigation();
+
                 // 攻擊只允許從本入口發起；怪物背景 worker 僅更新結果，不得自行送鍵。
                 if (CanStartAttack())
                     ProcessAutoAttackDecision();
 
-                if (trackingResult != null && !BlocksNavigationInput)
+                // 導航編排不因攻擊租約而停 tick；實際方向鍵由 MovementController 讓路。
+                if (trackingResult != null)
                     SignalNavigationOrchestration(trackingResult);
 
                 double msAfterPathAttack = sw.Elapsed.TotalMilliseconds;
@@ -429,7 +434,8 @@ namespace ArtaleAI.Application.Pipeline
         }
 
         /// <summary>
-        /// 攻擊決策的唯一閘門：換頻／清窗／退避／隊伍重建／進行中攻擊皆不可再開新攻擊。
+        /// 攻擊決策的唯一閘門：換頻／清窗／退避／隊伍重建／進行中攻擊／冷卻皆不可再開新攻擊。
+        /// 冷卻必須擋在入口，禁止「先 StopMovement 再因冷卻 return」空轉搶鍵。
         /// </summary>
         private bool CanStartAttack()
         {
@@ -440,18 +446,39 @@ namespace ArtaleAI.Application.Pipeline
                 && !_partyRecovery.IsRecovering
                 && !_farmUiInterrupt.IsDismissing
                 && Volatile.Read(ref _changeChannelInFlight) == 0
-                && Volatile.Read(ref _attackInputLease) == 0;
+                && Volatile.Read(ref _attackInputLease) == 0
+                && AttackInputArbiter.IsCooldownReady(_lastAttackTime, DateTime.UtcNow);
         }
 
-        /// <summary>已持有攻擊租約時，換頻／退避／補給撤退發生則應立刻中止後續按鍵。</summary>
+        /// <summary>已持有攻擊租約時，換頻／退避／休息／補給撤退／垂直導航發生則應立刻中止。</summary>
         private bool CanContinueAttack()
         {
             return AutoAttackEnabled
+                && _restPhase == RestPhaseNone
                 && _healRetreatPhase == HealRetreatNone
                 && !_otherPlayerAvoidance.IsAvoiding
                 && !_partyRecovery.IsRecovering
                 && !_farmUiInterrupt.IsDismissing
-                && Volatile.Read(ref _changeChannelInFlight) == 0;
+                && Volatile.Read(ref _changeChannelInFlight) == 0
+                && !ShouldDeferAttackForNavigation();
+        }
+
+        private bool IsCombatInputHeld() =>
+            _isAttacking
+            || Volatile.Read(ref _attackInputLease) > 0
+            || Volatile.Read(ref _heldAttackVirtualKey) != 0;
+
+        /// <summary>
+        /// 垂直換層／休息尋路等更高優先活動接管鍵盤前呼叫：
+        /// 立刻放鍵並釋放租約，避免 Walk／JumpDown 假啟動。
+        /// </summary>
+        public void PreemptCombatForNavigation()
+        {
+            AbortCombatInputs();
+            Interlocked.Exchange(ref _heldAttackVirtualKey, 0);
+            _isAttacking = false;
+            Interlocked.Exchange(ref _attackInputLease, 0);
+            _lastAttackTime = DateTime.UtcNow;
         }
 
         private bool ProcessAutoAttackDecision()
@@ -468,7 +495,7 @@ namespace ArtaleAI.Application.Pipeline
             return true;
         }
 
-        /// <summary>釋放方向鍵與主攻鍵，避免換頻／熄火時殘留 key-down。</summary>
+        /// <summary>釋放方向鍵與攻擊鍵，避免換頻／熄火時殘留 key-down。</summary>
         private void AbortCombatInputs()
         {
             _movementController?.StopMovement();
@@ -479,10 +506,15 @@ namespace ArtaleAI.Application.Pipeline
             _movementController.SendKeyInput(VK_RIGHT, keyUp: true);
             _movementController.SendKeyInput(VK_CONTROL, keyUp: true);
 
+            int heldVk = Interlocked.Exchange(ref _heldAttackVirtualKey, 0);
+            if (heldVk != 0)
+                _movementController.SendKeyInput((ushort)heldVk, keyUp: true);
+
             string? primary = AppConfig.Instance?.AutoFarm?.AttackPrimaryHotkey;
             if (!string.IsNullOrWhiteSpace(primary)
                 && VirtualKeyParser.TryParse(primary, out ushort primaryVk)
-                && primaryVk != VK_CONTROL)
+                && primaryVk != VK_CONTROL
+                && primaryVk != heldVk)
             {
                 _movementController.SendKeyInput(primaryVk, keyUp: true);
             }
@@ -511,6 +543,25 @@ namespace ArtaleAI.Application.Pipeline
             if (attackBox.IsEmpty)
                 return false;
 
+            targets = FilterAttackTargetsInBox(attackBox, monsters);
+            return targets.Count > 0;
+        }
+
+        /// <summary>以最新怪物清單重驗攻擊框內目標，避免殭屍偵測在怪死後仍出手。</summary>
+        private bool TryRefreshLiveAttackTargets(SdRect attackBox, out List<DetectionResult> targets)
+        {
+            List<DetectionResult> monsters;
+            lock (_monsterLock) monsters = _currentMonsters.ToList();
+            targets = FilterAttackTargetsInBox(attackBox, monsters);
+            return targets.Count > 0;
+        }
+
+        private List<DetectionResult> FilterAttackTargetsInBox(SdRect attackBox, IReadOnlyList<DetectionResult> monsters)
+        {
+            var targets = new List<DetectionResult>();
+            if (attackBox.IsEmpty || monsters.Count == 0)
+                return targets;
+
             int maxVerticalDelta = ResolveAttackMaxVerticalDeltaPx();
             float boxCenterY = attackBox.Y + attackBox.Height / 2f;
 
@@ -526,12 +577,12 @@ namespace ArtaleAI.Application.Pipeline
                 targets.Add(m);
             }
 
-            return targets.Count > 0;
+            return targets;
         }
 
         /// <summary>
-        /// 僅在垂直移動／跳躍飛行中暫緩攻擊；Walk 巡邏允許同層攻擊。
-        /// （先前「路徑未走完就不打」會導致巡邏永遠不攻擊。）
+        /// 垂直移動／跳躍／起跳對位期間暫緩攻擊；Walk 巡邏允許同層攻擊。
+        /// 必須在「飛行尚未開始、邊已是 JumpDown」時就讓出，否則長按會擋 ↓／Alt。
         /// </summary>
         private bool ShouldDeferAttackForNavigation()
         {
@@ -542,10 +593,15 @@ namespace ArtaleAI.Application.Pipeline
             if (_pathPlanningManager == null || !_pathPlanningManager.IsRunning)
                 return false;
 
-            if (!_pathPlanningManager.HasActiveNavigationFlight)
-                return false;
+            var tracker = _pathPlanningManager.Tracker;
+            if (tracker.IsSideJumpApproachInProgress)
+                return true;
 
-            return _pathPlanningManager.ActiveFlightActionType is
+            NavigationActionType? action =
+                _pathPlanningManager.ActiveFlightActionType
+                ?? tracker.CurrentNavigationEdge?.ActionType;
+
+            return action is
                 NavigationActionType.ClimbUp or
                 NavigationActionType.ClimbDown or
                 NavigationActionType.Jump or
@@ -691,6 +747,8 @@ namespace ArtaleAI.Application.Pipeline
             DateTime now,
             string prefix)
         {
+            // 休息尋路需要導航鍵；進行中長按必須立刻讓出。
+            PreemptCombatForNavigation();
             tracker.SetForcedGoal(spot.Id);
             _restSeekGoalNodeId = spot.Id;
             _restSeekStartedUtc = now;
@@ -768,6 +826,7 @@ namespace ArtaleAI.Application.Pipeline
             int durationSeconds = ResolveRestDurationSeconds(config.AutoFarm);
             _restPhase = RestPhaseResting;
             _restEndsAtUtc = now.AddSeconds(durationSeconds);
+            PreemptCombatForNavigation();
             _movementController?.StopMovement();
             OnStatusMessage?.Invoke(reason == null
                 ? $"已到休息點，小休約 {durationSeconds} 秒…"
@@ -1258,8 +1317,11 @@ namespace ArtaleAI.Application.Pipeline
             return baseValue * factor;
         }
 
-        /// <summary>轉向最近目標並送出攻擊鍵；租約已由呼叫端 CAS 取得，結束時釋放。</summary>
-        private async Task PerformAutoAttackAsync(SdRect playerBox, List<DetectionResult> targets)
+        /// <summary>
+        /// 轉向最近目標並送出攻擊鍵；租約已由呼叫端 CAS 取得，結束時釋放。
+        /// 主攻長按至框內無活怪；輪轉技仍為單次脈衝。
+        /// </summary>
+        private async Task PerformAutoAttackAsync(SdRect playerAttackBox, List<DetectionResult> targets)
         {
             try
             {
@@ -1267,72 +1329,164 @@ namespace ArtaleAI.Application.Pipeline
                 if (_movementController == null) return;
                 if (!CanContinueAttack()) return;
 
-                _movementController.StopMovement();
-
                 var now = DateTime.UtcNow;
-                if ((now - _lastAttackTime).TotalMilliseconds < AttackCooldownMs) return;
+                if (!AttackInputArbiter.IsCooldownReady(_lastAttackTime, now))
+                    return;
 
-                var playerCenter = new SdPoint(
-                    playerBox.X + playerBox.Width / 2,
-                    playerBox.Y + playerBox.Height / 2);
-                var target = targets.OrderBy(m =>
-                    Math.Abs((m.BoundingBox.X + m.BoundingBox.Width / 2) - playerCenter.X)).FirstOrDefault();
-                if (target == null) return;
+                if (!TryGetCurrentAttackBox(out SdRect attackBox))
+                    attackBox = playerAttackBox;
 
-                if ((now - _lastDirectionChangeTime).TotalMilliseconds > DirectionChangeCooldownMs)
-                {
-                    if (!CanContinueAttack()) return;
-
-                    int monsterCenterX = target.BoundingBox.X + target.BoundingBox.Width / 2;
-                    ushort directionKey = monsterCenterX < playerCenter.X ? VK_LEFT : VK_RIGHT;
-
-                    _movementController.SendKeyInput(directionKey, false);
-                    await Task.Delay(20).ConfigureAwait(false);
-                    _movementController.SendKeyInput(directionKey, true);
-                    _lastDirectionChangeTime = now;
-                }
-
-                if (!CanContinueAttack()) return;
+                if (!TryRefreshLiveAttackTargets(attackBox, out var liveTargets))
+                    return;
 
                 if (!_attackRotation.TrySelectAttackKey(
                         AppConfig.Instance.AutoFarm,
                         now,
                         out ushort attackKey,
-                        out string attackLabel))
+                        out string attackLabel,
+                        out bool useHoldAttack))
                 {
                     Logger.Warning("[自動攻擊] 主攻快捷鍵無法解析，略過此次攻擊");
                     return;
                 }
 
-                _movementController.SendKeyInput(attackKey, false);
-                await Task.Delay(20).ConfigureAwait(false);
-
-                // 換頻可能在 Delay 期間觸發：只送 key-up，不送第二次按下。
-                if (!CanContinueAttack())
-                {
-                    _movementController.SendKeyInput(attackKey, true);
+                if (!TryRefreshLiveAttackTargets(attackBox, out liveTargets))
                     return;
-                }
 
-                _movementController.SendKeyInput(attackKey, true);
+                _movementController.StopMovement();
+                await TryFaceNearestTargetAsync(attackBox, liveTargets).ConfigureAwait(false);
 
-                _lastAttackTime = now;
-                OnStatusMessage?.Invoke($"自動攻擊: 鎖定 {target.Name}（{attackLabel}）");
+                if (!CanContinueAttack() || ShouldDeferAttackForNavigation())
+                    return;
+
+                if (!TryRefreshLiveAttackTargets(attackBox, out liveTargets))
+                    return;
+
+                if (useHoldAttack)
+                    await HoldPrimaryAttackAsync(attackBox, attackKey, attackLabel, liveTargets).ConfigureAwait(false);
+                else
+                    await PulseSkillAttackAsync(attackBox, attackKey, attackLabel, liveTargets).ConfigureAwait(false);
             }
             finally
             {
+                ReleaseHeldAttackKey();
                 _isAttacking = false;
                 Interlocked.Exchange(ref _attackInputLease, 0);
             }
         }
 
-        /// <summary>每幀更新玩家座標 SSOT（攻擊期間仍執行）。</summary>
+        private bool TryGetCurrentAttackBox(out SdRect attackBox)
+        {
+            attackBox = _currentAttackRangeBoxes.FirstOrDefault();
+            return !attackBox.IsEmpty;
+        }
+
+        private static DetectionResult PickNearestTarget(SdRect attackBox, IReadOnlyList<DetectionResult> targets)
+        {
+            var playerCenter = new SdPoint(
+                attackBox.X + attackBox.Width / 2,
+                attackBox.Y + attackBox.Height / 2);
+
+            return targets.OrderBy(m =>
+                Math.Abs((m.BoundingBox.X + m.BoundingBox.Width / 2) - playerCenter.X)).First();
+        }
+
+        private async Task TryFaceNearestTargetAsync(SdRect attackBox, IReadOnlyList<DetectionResult> targets)
+        {
+            if (_movementController == null || targets.Count == 0)
+                return;
+
+            var now = DateTime.UtcNow;
+            if (!AttackInputArbiter.ShouldRetapFacing(_lastDirectionChangeTime, now))
+                return;
+
+            var target = PickNearestTarget(attackBox, targets);
+            var playerCenter = new SdPoint(
+                attackBox.X + attackBox.Width / 2,
+                attackBox.Y + attackBox.Height / 2);
+            int monsterCenterX = target.BoundingBox.X + target.BoundingBox.Width / 2;
+            ushort directionKey = monsterCenterX < playerCenter.X ? VK_LEFT : VK_RIGHT;
+
+            _movementController.SendKeyInput(directionKey, false);
+            await Task.Delay(AttackInputArbiter.SkillPulseMs).ConfigureAwait(false);
+            _movementController.SendKeyInput(directionKey, true);
+            _lastDirectionChangeTime = DateTime.UtcNow;
+        }
+
+        private void PressAttackKey(ushort attackKey)
+        {
+            Volatile.Write(ref _heldAttackVirtualKey, attackKey);
+            _movementController!.SendKeyInput(attackKey, false);
+        }
+
+        private void ReleaseHeldAttackKey()
+        {
+            int vk = Interlocked.Exchange(ref _heldAttackVirtualKey, 0);
+            if (vk != 0)
+                _movementController?.SendKeyInput((ushort)vk, true);
+        }
+
+        /// <summary>楓之谷主攻：長按至攻擊框內無活怪或導航需接管。</summary>
+        private async Task HoldPrimaryAttackAsync(
+            SdRect attackBox,
+            ushort attackKey,
+            string attackLabel,
+            List<DetectionResult> liveTargets)
+        {
+            var target = PickNearestTarget(attackBox, liveTargets);
+            PressAttackKey(attackKey);
+            OnStatusMessage?.Invoke($"自動攻擊: 按住 {target.Name}（{attackLabel}）");
+
+            var holdStarted = DateTime.UtcNow;
+            while (CanContinueAttack() && !ShouldDeferAttackForNavigation())
+            {
+                if ((DateTime.UtcNow - holdStarted).TotalMilliseconds >= AttackInputArbiter.MaxHoldMs)
+                    break;
+
+                if (!TryGetCurrentAttackBox(out attackBox))
+                    break;
+
+                if (!TryRefreshLiveAttackTargets(attackBox, out liveTargets))
+                    break;
+
+                await TryFaceNearestTargetAsync(attackBox, liveTargets).ConfigureAwait(false);
+                await Task.Delay(AttackInputArbiter.HoldPollMs).ConfigureAwait(false);
+            }
+
+            ReleaseHeldAttackKey();
+            _lastAttackTime = DateTime.UtcNow;
+        }
+
+        private async Task PulseSkillAttackAsync(
+            SdRect attackBox,
+            ushort attackKey,
+            string attackLabel,
+            List<DetectionResult> liveTargets)
+        {
+            var target = PickNearestTarget(attackBox, liveTargets);
+            _movementController!.SendKeyInput(attackKey, false);
+            await Task.Delay(AttackInputArbiter.SkillPulseMs).ConfigureAwait(false);
+
+            if (!CanContinueAttack())
+            {
+                _movementController.SendKeyInput(attackKey, true);
+                return;
+            }
+
+            _movementController.SendKeyInput(attackKey, true);
+            _lastAttackTime = DateTime.UtcNow;
+            OnStatusMessage?.Invoke($"自動攻擊: 鎖定 {target.Name}（{attackLabel}）");
+        }
+
+        /// <summary>每幀更新玩家座標 SSOT（攻擊期間仍執行）；並同步卡點豁免旗標。</summary>
         private void FeedPlayerTracking(MinimapTrackingResult result)
         {
             if (_pathPlanningManager == null || !_pathPlanningManager.IsRunning) return;
 
             try
             {
+                // 攻擊／換頻等佔鍵期間靜止是預期行為，不得累積卡點與救援熔斷。
+                _pathPlanningManager.Tracker.SuppressStuckDetection = BlocksNavigationInput;
                 _pathPlanningManager.ProcessTrackingResult(result);
             }
             catch (Exception ex)
@@ -1341,7 +1495,7 @@ namespace ArtaleAI.Application.Pipeline
             }
         }
 
-        /// <summary>攻擊未佔用輸入時，才推進導航 FSM tick。</summary>
+        /// <summary>推進導航 FSM tick（攻擊期間仍編排；送鍵由 MovementController 讓路）。</summary>
         private void SignalNavigationOrchestration(MinimapTrackingResult result)
         {
             if (_pathPlanningManager == null || !_pathPlanningManager.IsRunning) return;
@@ -1503,15 +1657,33 @@ namespace ArtaleAI.Application.Pipeline
 
         /// <summary>
         /// 怪物結果最大存活時間：來源幀年齡超過即整批清空釋放。
-        /// 取 3 個偵測週期（下限 250ms）容忍背景偵測的正常延遲，同時擋住卡頓後的殭屍資料。
+        /// 戰鬥中縮短殭屍框壽命，讓長按主攻較快在怪死後放開。
         /// </summary>
-        private static int ResolveMonsterResultMaxAgeMs(AppConfig config) =>
-            Math.Max(250, config.Vision.MonsterDetectIntervalMs * 3);
+        private static int ResolveMonsterResultMaxAgeMs(AppConfig config, bool combatActive)
+        {
+            int interval = Math.Max(50, config.Vision.MonsterDetectIntervalMs);
+            int multiplier = combatActive ? 2 : 3;
+            int floor = combatActive ? 180 : 250;
+            return Math.Max(floor, interval * multiplier);
+        }
+
+        private bool IsCombatMonsterRefreshActive() =>
+            _isAttacking || Volatile.Read(ref _heldAttackVirtualKey) != 0;
+
+        /// <summary>戰鬥期間加速怪物掃描，避免長按時仍吃 200ms 級殭屍框。</summary>
+        private int ResolveMonsterDetectIntervalMs(AppConfig config)
+        {
+            int interval = Math.Max(50, config.Vision.MonsterDetectIntervalMs);
+            if (!IsCombatMonsterRefreshActive())
+                return interval;
+
+            return Math.Max(80, interval / 2);
+        }
 
         /// <summary>來源幀過期的怪物結果整批清空，讓下游 fail-closed（無資料＝不攻擊）。</summary>
         private void PruneStaleMonsterResults(DateTime now, AppConfig config)
         {
-            int maxAgeMs = ResolveMonsterResultMaxAgeMs(config);
+            int maxAgeMs = ResolveMonsterResultMaxAgeMs(config, IsCombatMonsterRefreshActive());
             lock (_monsterLock)
             {
                 if (_currentMonsters.Count == 0)
@@ -1530,7 +1702,7 @@ namespace ArtaleAI.Application.Pipeline
         {
             // 無論目前有無命中，一律節流；否則「搜尋中」會每幀全模板比對，config 形同虛設。
             var elapsed = (now - _lastMonsterDetection).TotalMilliseconds;
-            if (elapsed < config.Vision.MonsterDetectIntervalMs) return;
+            if (elapsed < ResolveMonsterDetectIntervalMs(config)) return;
 
             if (!_currentDetectionBoxes.Any()) return;
             if (MonsterCatalog.IsEmpty) return;

--- a/Data/config.yaml
+++ b/Data/config.yaml
@@ -48,6 +48,7 @@ vision:
   - Color
   bloodBarDetectIntervalMs: 250
   monsterDetectIntervalMs: 200
+  frameDispatchIntervalMs: 0
   captureFrameRate: 15
   useFixedMinimapPosition: false
   fixedMinimapWidth: 250
@@ -87,6 +88,7 @@ navigation:
   ropeSegmentXTolerancePx: 1.5
   approachFailureRescueCutoff: 3
   rescueRepeatCutoff: 3
+  rescueCircuitCooldownSeconds: 20
   ropeHitboxWidth: 6
   ropeHitboxHeight: 15
   sideJumpAltHoldMs: 110
@@ -185,7 +187,7 @@ playerVitals:
   sampleRowCount: 0
   useAutoLayout: false
 autoFarm:
-  restIntervalMinutes: 1
+  restIntervalMinutes: 30
   restDurationSeconds: 60
   restJitterPercent: 20
   healHpEnabled: false

--- a/Domain/Navigation/NavigationRopeHelper.cs
+++ b/Domain/Navigation/NavigationRopeHelper.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using ArtaleAI.Shared;
 
 namespace ArtaleAI.Domain.Navigation
 {
-    /// <summary>爬繩邊的繩 X 解析與繩段幾何判定。</summary>
+    /// <summary>爬繩邊的繩 X 解析、繩段幾何判定，與掛繩途中改爬方向。</summary>
     public static class NavigationRopeHelper
     {
         /// <summary>從 Climb 邊 <c>InputSequence</c> 解析 ropeX；缺標記時回傳 false。</summary>
@@ -35,23 +34,126 @@ namespace ArtaleAI.Domain.Navigation
             float ropeXTolerancePx,
             float endpointYTolerancePx)
         {
-            foreach (var (ropeX, topY, bottomY) in ropeSegments)
+            return TryGetContainingRopeSegment(
+                playerPos,
+                ropeSegments,
+                ropeXTolerancePx,
+                endpointYTolerancePx,
+                out _);
+        }
+
+        /// <summary>若座標落在繩段內部，回傳該段；端點落點帶排除與 <see cref="IsPositionOnRope"/> 相同。</summary>
+        public static bool TryGetContainingRopeSegment(
+            PointF playerPos,
+            IReadOnlyList<(float X, float TopY, float BottomY)> ropeSegments,
+            float ropeXTolerancePx,
+            float endpointYTolerancePx,
+            out (float X, float TopY, float BottomY) segment)
+        {
+            segment = default;
+            foreach (var candidate in ropeSegments)
             {
-                if (Math.Abs(playerPos.X - ropeX) > ropeXTolerancePx)
+                if (Math.Abs(playerPos.X - candidate.X) > ropeXTolerancePx)
                     continue;
 
-                float minY = Math.Min(topY, bottomY);
-                float maxY = Math.Max(topY, bottomY);
+                float minY = Math.Min(candidate.TopY, candidate.BottomY);
+                float maxY = Math.Max(candidate.TopY, candidate.BottomY);
                 float innerMinY = minY + endpointYTolerancePx;
                 float innerMaxY = maxY - endpointYTolerancePx;
                 if (innerMinY > innerMaxY)
                     continue;
 
                 if (playerPos.Y >= innerMinY && playerPos.Y <= innerMaxY)
+                {
+                    segment = candidate;
                     return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 掛繩途中：依目標 Y 相對角色 Y 選 ClimbUp／ClimbDown（小地圖 Y 向下為正）。
+        /// 候選邊須帶 <c>ropeX:</c> 且對應當前繩段。
+        /// </summary>
+        public static bool TryPickClimbTowardGoal(RopeClimbPickQuery query, out RopeClimbPickResult result)
+        {
+            result = default;
+            if (query.Candidates == null || query.Candidates.Count == 0)
+                return false;
+
+            if (!TryGetContainingRopeSegment(
+                    query.PlayerPos,
+                    query.RopeSegments,
+                    query.RopeXTolerancePx,
+                    query.EndpointYTolerancePx,
+                    out var segment))
+                return false;
+
+            NavigationActionType desired = ResolveClimbDirection(query.PlayerPos.Y, query.GoalPos.Y);
+            if (TryFindCandidate(query.Candidates, segment.X, query.RopeXTolerancePx, desired, out result))
+                return true;
+
+            // 缺單向邊時退另一向，避免掛繩空轉。
+            var fallback = desired == NavigationActionType.ClimbUp
+                ? NavigationActionType.ClimbDown
+                : NavigationActionType.ClimbUp;
+            return TryFindCandidate(query.Candidates, segment.X, query.RopeXTolerancePx, fallback, out result);
+        }
+
+        /// <summary>目標 Y 較小＝上方 → ClimbUp；較大＝下方 → ClimbDown。</summary>
+        public static NavigationActionType ResolveClimbDirection(float playerY, float goalY)
+        {
+            const float tieEpsilonPx = 0.5f;
+            if (goalY < playerY - tieEpsilonPx)
+                return NavigationActionType.ClimbUp;
+            if (goalY > playerY + tieEpsilonPx)
+                return NavigationActionType.ClimbDown;
+
+            // Y 幾乎相同：保守往上離開繩中段（多數卡點目標在上層平台）。
+            return NavigationActionType.ClimbUp;
+        }
+
+        private static bool TryFindCandidate(
+            IReadOnlyList<ClimbEdgeCandidate> candidates,
+            float ropeX,
+            float ropeXTolerancePx,
+            NavigationActionType action,
+            out RopeClimbPickResult result)
+        {
+            result = default;
+            foreach (var candidate in candidates)
+            {
+                if (candidate.Edge.ActionType != action)
+                    continue;
+                if (!TryExtractRopeX(candidate.Edge, out float edgeRopeX))
+                    continue;
+                if (Math.Abs(edgeRopeX - ropeX) > ropeXTolerancePx)
+                    continue;
+
+                result = new RopeClimbPickResult(candidate.Edge, candidate.LandingPos);
+                return true;
             }
 
             return false;
         }
     }
+
+    /// <summary>圖上單條 Climb 邊與其落地座標。</summary>
+    public readonly record struct ClimbEdgeCandidate(NavigationEdge Edge, PointF LandingPos);
+
+    /// <summary>掛繩改爬查詢：角色／目標／繩段／候選 Climb 邊。</summary>
+    public sealed class RopeClimbPickQuery
+    {
+        public required PointF PlayerPos { get; init; }
+        public required PointF GoalPos { get; init; }
+        public required IReadOnlyList<(float X, float TopY, float BottomY)> RopeSegments { get; init; }
+        public required IReadOnlyList<ClimbEdgeCandidate> Candidates { get; init; }
+        public float RopeXTolerancePx { get; init; }
+        public float EndpointYTolerancePx { get; init; }
+    }
+
+    /// <summary>掛繩改爬結果。</summary>
+    public readonly record struct RopeClimbPickResult(NavigationEdge Edge, PointF LandingPos);
 }

--- a/MapData/ATTACK.json
+++ b/MapData/ATTACK.json
@@ -134,13 +134,13 @@
       "Id": "plat_7",
       "Points": [
         {
-          "X": 133.3,
-          "Y": 117.4,
+          "X": 135.5,
+          "Y": 117.6,
           "IsSafeZone": true
         },
         {
-          "X": 143.7,
-          "Y": 117.6,
+          "X": 145.9,
+          "Y": 117.5,
           "IsSafeZone": true
         }
       ]
@@ -236,13 +236,13 @@
   ],
   "ManualEdgeAnchors": [
     {
-      "FromPlatformId": "plat_8",
-      "FromX": 148.8,
-      "FromY": 121.7,
+      "FromPlatformId": "plat_7",
+      "FromX": 145.9,
+      "FromY": 117.5,
       "FromSegmentIndex": 0,
-      "ToPlatformId": "plat_7",
-      "ToX": 143.7,
-      "ToY": 117.6,
+      "ToPlatformId": "plat_8",
+      "ToX": 148.8,
+      "ToY": 121.7,
       "ToSegmentIndex": 0,
       "ActionType": 3
     }

--- a/Models/Config/NavigationSettings.cs
+++ b/Models/Config/NavigationSettings.cs
@@ -35,6 +35,12 @@ namespace ArtaleAI.Models.Config
         /// <summary>同座標、同補給節點連續救援達此值即熔斷，避免 livelock。</summary>
         public int RescueRepeatCutoff { get; set; } = 3;
 
+        /// <summary>
+        /// 救援熔斷冷卻（秒）。逾時自動解除，避免假卡點造成巡邏永久停走。
+        /// 設 0 表示不自動解除（僅位移／邊成功／Stop 時清除）。
+        /// </summary>
+        public int RescueCircuitCooldownSeconds { get; set; } = 20;
+
         /// <summary>繩索節點的到達判定寬度 (px)</summary>
         public double RopeHitboxWidth { get; set; } = 6.0;
 

--- a/Models/Config/VisionSettings.cs
+++ b/Models/Config/VisionSettings.cs
@@ -52,6 +52,13 @@ namespace ArtaleAI.Models.Config
 
         public int BloodBarDetectIntervalMs { get; set; } = 100;
         public int MonsterDetectIntervalMs { get; set; } = 100;
+
+        /// <summary>
+        /// LiveView 幀分發間隔（毫秒）。0 表示沿用 <see cref="MonsterDetectIntervalMs"/>。
+        /// 與怪物偵測解耦：可讓導航／小地圖較快更新，同時維持較慢的模板比對節流。
+        /// </summary>
+        public int FrameDispatchIntervalMs { get; set; }
+
         public int CaptureFrameRate { get; set; } = 30;
 
         public bool UseFixedMinimapPosition { get; set; } = false;

--- a/UI/LiveViewManager.cs
+++ b/UI/LiveViewManager.cs
@@ -55,8 +55,11 @@ namespace ArtaleAI.UI
 
                 int targetFPS = Math.Max(1, config.Vision.CaptureFrameRate);
                 int captureIntervalMs = 1000 / targetFPS;
-                // 與 monsterDetectIntervalMs 對齊：避免舊硬編碼 20ms 以 50Hz 空轉排程把管線打滿。
-                int dispatchIntervalMs = Math.Max(MinFrameDispatchIntervalMs, config.Vision.MonsterDetectIntervalMs);
+                int monsterIntervalMs = Math.Max(MinFrameDispatchIntervalMs, config.Vision.MonsterDetectIntervalMs);
+                int configuredDispatchMs = config.Vision.FrameDispatchIntervalMs;
+                int dispatchIntervalMs = configuredDispatchMs > 0
+                    ? Math.Max(MinFrameDispatchIntervalMs, configuredDispatchMs)
+                    : monsterIntervalMs;
 
                 _captureTimer = new System.Threading.Timer(OnCaptureTimer, null, 0, captureIntervalMs);
                 _detectionTimer = new System.Threading.Timer(OnDetectionTimer, null, dispatchIntervalMs, dispatchIntervalMs);

--- a/UI/MainForm.PathPlanning.cs
+++ b/UI/MainForm.PathPlanning.cs
@@ -82,9 +82,7 @@ namespace ArtaleAI
                                 return;
                             _gamePipeline.VisionDataReady = false;
 
-                            if (_gamePipeline.BlocksNavigationInput)
-                                return;
-
+                            // 攻擊租約只擋方向鍵（MovementController 讓路），不應擋 FSM tick。
                             var tracker = _pathPlanningManager?.Tracker;
                             if (tracker?.IsRescueCircuitBroken == true)
                             {
@@ -96,8 +94,53 @@ namespace ArtaleAI
                             NavigationEdge? edgeToExecute = currentEdge;
                             var executeTarget = nextWaypoint;
 
+                            // 掛繩時必須先離繩；不可先跑 JumpDown 起跳檢查（會誤救援熔斷）。
+                            if (tracker != null &&
+                                tracker.IsPlayerOnRope((System.Drawing.PointF)playerPos))
+                            {
+                                var climbGoal = pathState.PlannedPath.Count > 0
+                                    ? pathState.PlannedPath[^1]
+                                    : executeTarget;
+
+                                if (tracker.TryResolveRopeClimbTowardGoal(
+                                        (System.Drawing.PointF)playerPos,
+                                        (System.Drawing.PointF)climbGoal,
+                                        out var ropeClimb,
+                                        out var ropeLanding) &&
+                                    ropeClimb != null)
+                                {
+                                    _gamePipeline.PreemptCombatForNavigation();
+                                    tracker.MarkRopeDismountClimbStarted();
+                                    Logger.Info(
+                                        $"[導航] 掛繩改爬 {ropeClimb.ActionType} " +
+                                        $"player=({playerPos.X:F1},{playerPos.Y:F1}) " +
+                                        $"goalY={climbGoal.Y:F1} landing=({ropeLanding.X:F1},{ropeLanding.Y:F1})");
+
+                                    if (_fsm != null &&
+                                        _fsm.TryStartNavigation(
+                                            ropeClimb, (SdPointF)playerPos, (SdPointF)ropeLanding))
+                                    {
+                                        ReportAction($"{ropeClimb.ActionType}");
+                                    }
+
+                                    return;
+                                }
+
+                                Logger.Warning(
+                                    $"[導航] 掛繩但找不到 Climb 邊，暫不執行 " +
+                                    $"player=({playerPos.X:F1},{playerPos.Y:F1})");
+                                return;
+                            }
+
                             bool needsJumpApproach = currentEdge?.ActionType is
                                 NavigationActionType.Jump or NavigationActionType.SideJump or NavigationActionType.JumpDown;
+
+                            // 換層邊／起跳對位前先搶回攻擊租約，避免 ↓／Alt 被長按擋下。
+                            bool needsVerticalPriority = needsJumpApproach
+                                || currentEdge?.ActionType is
+                                    NavigationActionType.ClimbUp or NavigationActionType.ClimbDown;
+                            if (needsVerticalPriority)
+                                _gamePipeline.PreemptCombatForNavigation();
 
                             if (needsJumpApproach &&
                                 tracker != null &&
@@ -133,9 +176,6 @@ namespace ArtaleAI
 
                             Logger.Info($"[導航狀態] 玩家=({playerPos.X:F1},{playerPos.Y:F1}) 目標=({executeTarget.X:F1},{executeTarget.Y:F1}) Edge={edgeToExecute?.FromNodeId}->{edgeToExecute?.ToNodeId} Action={edgeToExecute?.ActionType}");
 
-                            bool walkEdge = edgeToExecute != null &&
-                                            edgeToExecute.ActionType == NavigationActionType.Walk;
-
                             if (edgeToExecute == null)
                             {
                                 Logger.Error($"[導航狀態] 無合法導航邊可執行，停止自動導航。玩家=({playerPos.X:F1},{playerPos.Y:F1})");
@@ -143,13 +183,7 @@ namespace ArtaleAI
                                 return;
                             }
 
-                            if (walkEdge &&
-                                tracker != null &&
-                                tracker.IsPlayerOnRope((System.Drawing.PointF)playerPos))
-                            {
-                                Logger.Debug($"[導航] 仍在繩上，暫不啟動 Walk player=({playerPos.X:F1},{playerPos.Y:F1})");
-                            }
-                            else if (_fsm != null &&
+                            if (_fsm != null &&
                                 _fsm.TryStartNavigation(edgeToExecute, (SdPointF)playerPos, (SdPointF)executeTarget))
                             {
                                 ReportAction($"{edgeToExecute.ActionType}");

--- a/Vision/PathPlanningTracker.cs
+++ b/Vision/PathPlanningTracker.cs
@@ -63,14 +63,22 @@ namespace ArtaleAI.Vision
 
         private bool _sideJumpApproachInProgress;
         private string? _sideJumpApproachFromNodeId;
+        /// <summary>掛繩時誤排 Walk，改執行離繩 Climb；完成後不推進巡邏 waypoint。</summary>
+        private bool _ropeDismountClimbInProgress;
         private PlatformGeometryIndex _platformGeometry = PlatformGeometryIndex.Empty;
         private string? _approachFailNodeId;
         private int _approachFailCount;
         private readonly HashSet<string> _approachCutoffNodes = new(StringComparer.Ordinal);
 
         private bool _rescueCircuitBroken;
+        private DateTime _rescueCircuitBrokenUtc = DateTime.MinValue;
         private string? _lastRescueKey;
         private int _consecutiveSameRescueCount;
+
+        /// <summary>
+        /// 由 Pipeline 設定：攻擊租約／換頻等讓導航鍵時，靜止是預期行為，不可當卡點。
+        /// </summary>
+        public volatile bool SuppressStuckDetection;
 
         private readonly object _flightLock = new();
         private NavigationFlight? _activeFlight;
@@ -248,6 +256,13 @@ namespace ArtaleAI.Vision
                 return null;
             }
 
+            // Climb 凍結目標綁 edge.ToNode（含掛繩離繩改爬），不可用巡邏 Walk 的 waypoint。
+            if (frozen && edge != null &&
+                edge.ActionType is NavigationActionType.ClimbUp or NavigationActionType.ClimbDown)
+            {
+                return ResolveClimbLandingTarget(edge);
+            }
+
             if (!frozen)
             {
                 var state = CurrentPathState;
@@ -266,7 +281,7 @@ namespace ArtaleAI.Vision
                 return null;
             }
 
-            NavigationEdge? policyEdge = frozen ? edge : CurrentNavigationEdge;
+            NavigationEdge? policyEdge = CurrentNavigationEdge;
             if (policyEdge?.ActionType is NavigationActionType.ClimbUp or NavigationActionType.ClimbDown)
             {
                 if (!NavigationRopeHelper.TryExtractRopeX(policyEdge, out float ropeX))
@@ -281,6 +296,26 @@ namespace ArtaleAI.Vision
             }
 
             return ExecutionTargetTranslator.ForWaypoint(waypointNode);
+        }
+
+        private ExecutionTarget? ResolveClimbLandingTarget(NavigationEdge climbEdge)
+        {
+            var landingNode = _navGraph?.GetNode(climbEdge.ToNodeId);
+            if (landingNode == null)
+            {
+                Logger.Error(
+                    $"[導航] Climb 落地節點不存在 to={climbEdge.ToNodeId}");
+                return null;
+            }
+
+            if (!NavigationRopeHelper.TryExtractRopeX(climbEdge, out float ropeX))
+            {
+                Logger.Error(
+                    $"[導航] Climb 邊缺少 ropeX metadata edge={FormatEdgeLabel(climbEdge)}");
+                return null;
+            }
+
+            return ExecutionTargetTranslator.ForRopeLanding(landingNode, ropeX);
         }
 
         private static string FormatEdgeLabel(NavigationEdge? edge) =>
@@ -303,6 +338,10 @@ namespace ArtaleAI.Vision
         {
             lock (_flightLock)
                 ClearNavigationFlightInternal();
+
+            // 飛行中斷時也要清，避免下一次正常 Walk 誤跳過 waypoint 推進。
+            if (_ropeDismountClimbInProgress)
+                ClearRopeDismountClimbState();
         }
 
         /// <summary>
@@ -378,6 +417,59 @@ namespace ArtaleAI.Vision
                 (float)nav.RopeSegmentXTolerancePx,
                 (float)nav.RopeLandingYTolerancePx);
         }
+
+        /// <summary>
+        /// 掛繩且誤排 Walk 時：依目標 Y 選 ClimbUp／ClimbDown，落地後可再走。
+        /// </summary>
+        public bool TryResolveRopeClimbTowardGoal(
+            PointF playerPos,
+            PointF goalPos,
+            out NavigationEdge? climbEdge,
+            out PointF landingPos)
+        {
+            climbEdge = null;
+            landingPos = default;
+            if (_navGraph == null)
+                return false;
+
+            var nav = AppConfig.Instance.Navigation;
+            var candidates = new List<ClimbEdgeCandidate>();
+            foreach (var node in _navGraph.GetAllNodes())
+            {
+                foreach (var edge in _navGraph.GetOutgoingEdges(node.Id))
+                {
+                    if (edge.ActionType is not (NavigationActionType.ClimbUp or NavigationActionType.ClimbDown))
+                        continue;
+                    var toNode = _navGraph.GetNode(edge.ToNodeId);
+                    if (toNode == null)
+                        continue;
+                    candidates.Add(new ClimbEdgeCandidate(edge, toNode.Position));
+                }
+            }
+
+            var query = new RopeClimbPickQuery
+            {
+                PlayerPos = playerPos,
+                GoalPos = goalPos,
+                RopeSegments = _mapRopeSegmentsForVisualization,
+                Candidates = candidates,
+                RopeXTolerancePx = (float)nav.RopeSegmentXTolerancePx,
+                EndpointYTolerancePx = (float)nav.RopeLandingYTolerancePx
+            };
+
+            if (!NavigationRopeHelper.TryPickClimbTowardGoal(query, out var picked))
+                return false;
+
+            climbEdge = picked.Edge;
+            landingPos = picked.LandingPos;
+            return true;
+        }
+
+        public void MarkRopeDismountClimbStarted() => _ropeDismountClimbInProgress = true;
+
+        public bool IsRopeDismountClimbInProgress => _ropeDismountClimbInProgress;
+
+        public void ClearRopeDismountClimbState() => _ropeDismountClimbInProgress = false;
 
         /// <summary>
         /// Jump / SideJump / JumpDown 前若尚未站在 from 節點 Hitbox，回傳需先執行的 Walk 邊與目標座標。
@@ -605,6 +697,11 @@ namespace ArtaleAI.Vision
                         ClearSideJumpApproachState();
                         Logger.Info("[路徑追蹤] 跳躍起跳點已對齊，下帧執行跳躍動作。");
                     }
+                    else if (_ropeDismountClimbInProgress)
+                    {
+                        ClearRopeDismountClimbState();
+                        Logger.Info("[路徑追蹤] 掛繩離繩完成，不推進巡邏 waypoint，下帧可啟動 Walk。");
+                    }
                     else
                     {
                         Logger.Info($"[路徑追蹤] FSM 驗收成功，正式推進進度。");
@@ -654,6 +751,44 @@ namespace ArtaleAI.Vision
             _lastRescueKey = null;
             _consecutiveSameRescueCount = 0;
             _rescueCircuitBroken = false;
+            _rescueCircuitBrokenUtc = DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// 自動打怪 Stop／Start 時呼叫：清掉熔斷、Approach 黑名單與殘留飛行，
+        /// 避免「關掉再開」仍被舊熔斷擋死無法恢復巡邏。
+        /// </summary>
+        public void ResetFarmSessionState()
+        {
+            SuppressStuckDetection = false;
+            ResetRescueCircuitBreaker();
+            ClearSideJumpApproachState();
+            ClearRopeDismountClimbState();
+            _approachCutoffNodes.Clear();
+            _approachFailNodeId = null;
+            _approachFailCount = 0;
+            ClearForcedGoal();
+            EndNavigationFlight();
+            _lastPosition = null;
+            _lastMovementUtc = DateTime.UtcNow;
+            Logger.Info("[路徑追蹤] 已重置打怪工作階段狀態（熔斷／Approach／強制目標）");
+        }
+
+        /// <summary>熔斷冷卻到期則自動解除，避免假卡點造成巡邏永久停走。</summary>
+        private void TryRecoverRescueCircuitBreaker()
+        {
+            if (!_rescueCircuitBroken)
+                return;
+
+            int cooldownSec = AppConfig.Instance?.Navigation?.RescueCircuitCooldownSeconds ?? 20;
+            if (cooldownSec <= 0)
+                return;
+
+            if ((DateTime.UtcNow - _rescueCircuitBrokenUtc).TotalSeconds < cooldownSec)
+                return;
+
+            Logger.Info($"[導航救援] 熔斷冷卻結束（{cooldownSec}s），恢復救援與導航編排");
+            ResetRescueCircuitBreaker();
         }
 
 
@@ -711,6 +846,7 @@ namespace ArtaleAI.Vision
         public void ProcessTrackingResult(MinimapTrackingResult? result)
         {
             if (result == null) return;
+            TryRecoverRescueCircuitBreaker();
             UpdateTrackingHistory(result);
             UpdatePathState(result);
         }
@@ -739,8 +875,8 @@ namespace ArtaleAI.Vision
             }
             else
             {
-                // 強制目標已到達＝休息倒數中，靜止是預期行為，不可當卡點。
-                if (_forcedGoalArrived)
+                // 休息倒數／攻擊佔鍵等：靜止是預期行為，不可當卡點、不可累積救援熔斷。
+                if (_forcedGoalArrived || SuppressStuckDetection)
                 {
                     _lastMovementUtc = DateTime.UtcNow;
                     return;
@@ -1201,6 +1337,15 @@ namespace ArtaleAI.Vision
             EndNavigationFlight();
             ClearSideJumpApproachState();
 
+            // 掛繩時吸到平台再排 JumpDown 會立刻再次救援並熔斷；交給編排層先離繩。
+            if (IsPlayerOnRope(currentPos))
+            {
+                Logger.Warning(
+                    $"[導航救援] 角色仍在繩上，跳過平台吸點重規劃 " +
+                    $"player=({currentPos.X:F1},{currentPos.Y:F1})");
+                return false;
+            }
+
             var nearestNode = _navGraph.FindNearestNode(currentPos, 150.0f);
 
             if (nearestNode == null)
@@ -1285,8 +1430,11 @@ namespace ArtaleAI.Vision
                 return true;
 
             _rescueCircuitBroken = true;
+            _rescueCircuitBrokenUtc = DateTime.UtcNow;
+            int cooldownSec = AppConfig.Instance?.Navigation?.RescueCircuitCooldownSeconds ?? 20;
+            string cooldownHint = cooldownSec > 0 ? $"，{cooldownSec}s 後自動解除" : "（需位移或重啟才解除）";
             Logger.Error(
-                $"[導航救援] 熔斷觸發：同導航鍵 {rescueKey} 連續救援 {_consecutiveSameRescueCount} 次，停止重試 (blocked/stuck)。");
+                $"[導航救援] 熔斷觸發：同導航鍵 {rescueKey} 連續救援 {_consecutiveSameRescueCount} 次，停止重試 (blocked/stuck){cooldownHint}。");
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- 掛繩時優先改爬（依目標 Y），避免誤排 Walk／JumpDown 後救援熔斷停走
- 掛繩救援改為跳過平台吸點重規劃，交給編排層離繩
- 攻擊輸入仲裁與長按攻擊，導航可搶回垂直鍵租約

## Test plan
- [ ] 角色掛在繩中段啟動自動巡邏：應自動 Climb，不瞬間熔斷
- [ ] 目標在上方／下方時分別 ClimbUp／ClimbDown
- [ ] 平台 Walk／換層 Climb 正常巡邏一段時間
- [ ] 攻擊與導航交替時方向鍵／爬繩鍵不被長按卡住
